### PR TITLE
[PLAC-11370] add fsq -> legacy mappings

### DIFF
--- a/categories/integrated_places_files/factual_to_integrated.json
+++ b/categories/integrated_places_files/factual_to_integrated.json
@@ -1,872 +1,9 @@
 {
-  "2": {
-    "factual_label": "Automotive",
-    "single_match": {
-      "integrated_category_id": "11000",
-      "integrated_category_label": "Business and Professional Services",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "11009",
-        "integrated_category_label": "Business and Professional Services > Automotive Service",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "17005",
-        "integrated_category_label": "Retail > Automotive Retail",
-        "is_exact": true
-      }
-    ]
-  },
-  "3": {
-    "factual_label": "Automotive > Car Appraisers",
-    "single_match": {
-      "integrated_category_id": "11009",
-      "integrated_category_label": "Business and Professional Services > Automotive Service",
-      "is_exact": false
-    }
-  },
-  "4": {
-    "factual_label": "Automotive > Car Dealers and Leasing",
-    "single_match": {
-      "integrated_category_id": "17006",
-      "integrated_category_label": "Retail > Automotive Retail > Car Dealership",
-      "is_exact": true
-    }
-  },
-  "5": {
-    "factual_label": "Automotive > Car Dealers and Leasing > Used Cars",
-    "single_match": {
-      "integrated_category_id": "17010",
-      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > Used Car Dealership",
-      "is_exact": true
-    }
-  },
-  "6": {
-    "factual_label": "Automotive > Car Parts and Accessories",
-    "single_match": {
-      "integrated_category_id": "17011",
-      "integrated_category_label": "Retail > Automotive Retail > Car Parts and Accessories",
-      "is_exact": true
-    }
-  },
-  "7": {
-    "factual_label": "Automotive > Car Wash and Detail",
-    "single_match": {
-      "integrated_category_id": "11011",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Car Wash and Detail",
-      "is_exact": true
-    }
-  },
-  "8": {
-    "factual_label": "Automotive > Classic and Antique Car",
-    "single_match": {
-      "integrated_category_id": "17007",
-      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > Classic and Antique Car Dealership",
-      "is_exact": true
-    }
-  },
-  "9": {
-    "factual_label": "Automotive > Maintenance and Repair",
-    "single_match": {
-      "integrated_category_id": "11010",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Automotive Repair Shop",
-      "is_exact": true
-    }
-  },
   "10": {
     "factual_label": "Automotive > Maintenance and Repair > Oil and Lube",
     "single_match": {
       "integrated_category_id": "11013",
       "integrated_category_label": "Business and Professional Services > Automotive Service > Oil Change Service",
-      "is_exact": true
-    }
-  },
-  "11": {
-    "factual_label": "Automotive > Maintenance and Repair > Smog Check",
-    "single_match": {
-      "integrated_category_id": "11014",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Smog Check Shop",
-      "is_exact": true
-    }
-  },
-  "12": {
-    "factual_label": "Automotive > Maintenance and Repair > Tires",
-    "single_match": {
-      "integrated_category_id": "11015",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Tire Repair Shop",
-      "is_exact": true
-    }
-  },
-  "13": {
-    "factual_label": "Automotive > Maintenance and Repair > Transmissions",
-    "single_match": {
-      "integrated_category_id": "11017",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Transmissions Shop",
-      "is_exact": true
-    }
-  },
-  "14": {
-    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters",
-    "single_match": {
-      "integrated_category_id": "11009",
-      "integrated_category_label": "Business and Professional Services > Automotive Service",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "11009",
-        "integrated_category_label": "Business and Professional Services > Automotive Service",
-        "is_exact": false
-      },
-      {
-        "integrated_category_id": "11012",
-        "integrated_category_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "17012",
-        "integrated_category_label": "Retail > Automotive Retail > Motorcycle Dealership",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "17013",
-        "integrated_category_label": "Retail > Automotive Retail > Motorsports Store",
-        "is_exact": true
-      }
-    ]
-  },
-  "15": {
-    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters > Repair",
-    "single_match": {
-      "integrated_category_id": "11012",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
-      "is_exact": true
-    }
-  },
-  "16": {
-    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters > Sales",
-    "single_match": {
-      "integrated_category_id": "17012",
-      "integrated_category_label": "Retail > Automotive Retail > Motorcycle Dealership",
-      "is_exact": true
-    }
-  },
-  "17": {
-    "factual_label": "Automotive > RVs and Motor Homes",
-    "single_match": {
-      "integrated_category_id": "17009",
-      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > RV and Motorhome Dealership",
-      "is_exact": true
-    }
-  },
-  "18": {
-    "factual_label": "Automotive > Salvage Yards",
-    "single_match": {
-      "integrated_category_id": "11160",
-      "integrated_category_label": "Business and Professional Services > Salvage Yard",
-      "is_exact": true
-    }
-  },
-  "19": {
-    "factual_label": "Automotive > Towing",
-    "single_match": {
-      "integrated_category_id": "11016",
-      "integrated_category_label": "Business and Professional Services > Automotive Service > Towing Service",
-      "is_exact": true
-    }
-  },
-  "20": {
-    "factual_label": "Community and Government",
-    "single_match": {
-      "integrated_category_id": "12000",
-      "integrated_category_label": "Community and Government",
-      "is_exact": true
-    }
-  },
-  "21": {
-    "factual_label": "Community and Government > Animal Shelters and Humane Societies",
-    "single_match": {
-      "integrated_category_id": "12002",
-      "integrated_category_label": "Community and Government > Animal Shelter",
-      "is_exact": true
-    }
-  },
-  "22": {
-    "factual_label": "Community and Government > Cemeteries",
-    "single_match": {
-      "integrated_category_id": "12003",
-      "integrated_category_label": "Community and Government > Cemetery",
-      "is_exact": true
-    }
-  },
-  "23": {
-    "factual_label": "Community and Government > Day Care and Preschools",
-    "single_match": {
-      "integrated_category_id": "12000",
-      "integrated_category_label": "Community and Government",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "11026",
-        "integrated_category_label": "Business and Professional Services > Child Care Service > Daycare",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "12056",
-        "integrated_category_label": "Community and Government > Education > Preschool",
-        "is_exact": true
-      }
-    ]
-  },
-  "24": {
-    "factual_label": "Community and Government > Disabled Persons Services",
-    "single_match": {
-      "integrated_category_id": "12006",
-      "integrated_category_label": "Community and Government > Disabled Persons Service",
-      "is_exact": true
-    }
-  },
-  "25": {
-    "factual_label": "Community and Government > Drug and Alcohol Services",
-    "single_match": {
-      "integrated_category_id": "12001",
-      "integrated_category_label": "Community and Government > Addiction Treatment Center",
-      "is_exact": true
-    }
-  },
-  "26": {
-    "factual_label": "Community and Government > Education",
-    "single_match": {
-      "integrated_category_id": "12009",
-      "integrated_category_label": "Community and Government > Education",
-      "is_exact": true
-    }
-  },
-  "27": {
-    "factual_label": "Community and Government > Education > Adult Education",
-    "single_match": {
-      "integrated_category_id": "12010",
-      "integrated_category_label": "Community and Government > Education > Adult Education",
-      "is_exact": true
-    }
-  },
-  "28": {
-    "factual_label": "Community and Government > Education > Art Lessons and Schools",
-    "single_match": {
-      "integrated_category_id": "12011",
-      "integrated_category_label": "Community and Government > Education > Art School",
-      "is_exact": true
-    }
-  },
-  "29": {
-    "factual_label": "Community and Government > Education > Colleges and Universities",
-    "single_match": {
-      "integrated_category_id": "12013",
-      "integrated_category_label": "Community and Government > Education > College and University",
-      "is_exact": true
-    }
-  },
-  "30": {
-    "factual_label": "Community and Government > Education > Computer Training",
-    "single_match": {
-      "integrated_category_id": "12049",
-      "integrated_category_label": "Community and Government > Education > Computer Training School",
-      "is_exact": true
-    }
-  },
-  "31": {
-    "factual_label": "Community and Government > Education > Culinary Lessons and Schools",
-    "single_match": {
-      "integrated_category_id": "12050",
-      "integrated_category_label": "Community and Government > Education > Culinary School",
-      "is_exact": true
-    }
-  },
-  "32": {
-    "factual_label": "Community and Government > Education > Driving Schools",
-    "single_match": {
-      "integrated_category_id": "12051",
-      "integrated_category_label": "Community and Government > Education > Driving School",
-      "is_exact": true
-    }
-  },
-  "33": {
-    "factual_label": "Community and Government > Education > Fraternities and Sororities",
-    "single_match": {
-      "integrated_category_id": "12013",
-      "integrated_category_label": "Community and Government > Education > College and University",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "12043",
-        "integrated_category_label": "Community and Government > Education > College and University > Fraternity House",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "12046",
-        "integrated_category_label": "Community and Government > Education > College and University > Sorority House",
-        "is_exact": true
-      }
-    ]
-  },
-  "34": {
-    "factual_label": "Community and Government > Education > Primary and Secondary Schools",
-    "single_match": {
-      "integrated_category_id": "12057",
-      "integrated_category_label": "Community and Government > Education > Primary and Secondary School",
-      "is_exact": true
-    }
-  },
-  "35": {
-    "factual_label": "Community and Government > Education > Tutoring and Educational Services",
-    "single_match": {
-      "integrated_category_id": "11172",
-      "integrated_category_label": "Business and Professional Services > Tutoring Service",
-      "is_exact": true
-    }
-  },
-  "36": {
-    "factual_label": "Community and Government > Education > Vocational Schools",
-    "single_match": {
-      "integrated_category_id": "12063",
-      "integrated_category_label": "Community and Government > Education > Trade School",
-      "is_exact": true
-    }
-  },
-  "37": {
-    "factual_label": "Community and Government > Government Departments and Agencies",
-    "single_match": {
-      "integrated_category_id": "12069",
-      "integrated_category_label": "Community and Government > Government Building > Government Department / Agency",
-      "is_exact": true
-    }
-  },
-  "38": {
-    "factual_label": "Community and Government > Government Lobbyists",
-    "single_match": {
-      "integrated_category_id": "12076",
-      "integrated_category_label": "Community and Government > Government Lobbyist",
-      "is_exact": true
-    }
-  },
-  "39": {
-    "factual_label": "Community and Government > Housing Assistance and Shelters",
-    "single_match": {
-      "integrated_category_id": "12077",
-      "integrated_category_label": "Community and Government > Homeless Shelter",
-      "is_exact": true
-    }
-  },
-  "40": {
-    "factual_label": "Community and Government > Law Enforcement and Public Safety",
-    "single_match": {
-      "integrated_category_id": "12070",
-      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety",
-      "is_exact": true
-    }
-  },
-  "41": {
-    "factual_label": "Community and Government > Law Enforcement and Public Safety > Rescue Services",
-    "single_match": {
-      "integrated_category_id": "15008",
-      "integrated_category_label": "Health and Medicine > Emergency Service",
-      "is_exact": false
-    }
-  },
-  "42": {
-    "factual_label": "Community and Government > Law Enforcement and Public Safety > Fire Stations",
-    "single_match": {
-      "integrated_category_id": "12071",
-      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Fire Station",
-      "is_exact": true
-    }
-  },
-  "43": {
-    "factual_label": "Community and Government > Law Enforcement and Public Safety > Police Stations",
-    "single_match": {
-      "integrated_category_id": "12072",
-      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Police Station",
-      "is_exact": true
-    }
-  },
-  "44": {
-    "factual_label": "Community and Government > Libraries",
-    "single_match": {
-      "integrated_category_id": "12080",
-      "integrated_category_label": "Community and Government > Library",
-      "is_exact": true
-    }
-  },
-  "45": {
-    "factual_label": "Community and Government > Military",
-    "single_match": {
-      "integrated_category_id": "12073",
-      "integrated_category_label": "Community and Government > Government Building > Military",
-      "is_exact": true
-    }
-  },
-  "46": {
-    "factual_label": "Community and Government > Military > Bases",
-    "single_match": {
-      "integrated_category_id": "12074",
-      "integrated_category_label": "Community and Government > Government Building > Military > Military Base",
-      "is_exact": true
-    }
-  },
-  "47": {
-    "factual_label": "Community and Government > Organizations and Associations",
-    "single_match": {
-      "integrated_category_id": "12082",
-      "integrated_category_label": "Community and Government > Organization",
-      "is_exact": true
-    }
-  },
-  "48": {
-    "factual_label": "Community and Government > Organizations and Associations > Charities and Non-Profits",
-    "single_match": {
-      "integrated_category_id": "12083",
-      "integrated_category_label": "Community and Government > Organization > Charity",
-      "is_exact": true
-    }
-  },
-  "49": {
-    "factual_label": "Community and Government > Organizations and Associations > Environmental",
-    "single_match": {
-      "integrated_category_id": "12085",
-      "integrated_category_label": "Community and Government > Organization > Environmental Organization",
-      "is_exact": true
-    }
-  },
-  "50": {
-    "factual_label": "Community and Government > Organizations and Associations > Youth Organizations",
-    "single_match": {
-      "integrated_category_id": "12089",
-      "integrated_category_label": "Community and Government > Organization > Youth Organization",
-      "is_exact": true
-    }
-  },
-  "51": {
-    "factual_label": "Community and Government > Post Offices",
-    "single_match": {
-      "integrated_category_id": "12075",
-      "integrated_category_label": "Community and Government > Government Building > Post Office",
-      "is_exact": true
-    }
-  },
-  "52": {
-    "factual_label": "Community and Government > Public and Social Services",
-    "single_match": {
-      "integrated_category_id": "12091",
-      "integrated_category_label": "Community and Government > Public and Social Service",
-      "is_exact": true
-    }
-  },
-  "53": {
-    "factual_label": "Community and Government > Religious",
-    "single_match": {
-      "integrated_category_id": "12098",
-      "integrated_category_label": "Community and Government > Spiritual Center",
-      "is_exact": true
-    }
-  },
-  "54": {
-    "factual_label": "Community and Government > Religious > Buddhist Temples",
-    "single_match": {
-      "integrated_category_id": "12099",
-      "integrated_category_label": "Community and Government > Spiritual Center > Buddhist Temple",
-      "is_exact": true
-    }
-  },
-  "55": {
-    "factual_label": "Community and Government > Religious > Churches",
-    "single_match": {
-      "integrated_category_id": "12101",
-      "integrated_category_label": "Community and Government > Spiritual Center > Church",
-      "is_exact": true
-    }
-  },
-  "56": {
-    "factual_label": "Community and Government > Religious > Hindu Temples",
-    "single_match": {
-      "integrated_category_id": "12103",
-      "integrated_category_label": "Community and Government > Spiritual Center > Hindu Temple",
-      "is_exact": true
-    }
-  },
-  "57": {
-    "factual_label": "Community and Government > Religious > Mosques",
-    "single_match": {
-      "integrated_category_id": "12106",
-      "integrated_category_label": "Community and Government > Spiritual Center > Mosque",
-      "is_exact": true
-    }
-  },
-  "58": {
-    "factual_label": "Community and Government > Religious > Synagogues",
-    "single_match": {
-      "integrated_category_id": "12110",
-      "integrated_category_label": "Community and Government > Spiritual Center > Synagogue",
-      "is_exact": true
-    }
-  },
-  "59": {
-    "factual_label": "Community and Government > Senior Citizen Services",
-    "single_match": {
-      "integrated_category_id": "12096",
-      "integrated_category_label": "Community and Government > Senior Citizen Service",
-      "is_exact": true
-    }
-  },
-  "60": {
-    "factual_label": "Community and Government > Senior Citizen Services > Retirement",
-    "single_match": {
-      "integrated_category_id": "12095",
-      "integrated_category_label": "Community and Government > Retirement Home",
-      "is_exact": true
-    }
-  },
-  "61": {
-    "factual_label": "Community and Government > Utility Companies",
-    "single_match": {
-      "integrated_category_id": "12115",
-      "integrated_category_label": "Community and Government > Utility Company",
-      "is_exact": true
-    }
-  },
-  "62": {
-    "factual_label": "Healthcare",
-    "single_match": {
-      "integrated_category_id": "15000",
-      "integrated_category_label": "Health and Medicine",
-      "is_exact": true
-    }
-  },
-  "63": {
-    "factual_label": "Healthcare > AIDS Resources",
-    "single_match": {
-      "integrated_category_id": "15002",
-      "integrated_category_label": "Health and Medicine > AIDS Resource",
-      "is_exact": true
-    }
-  },
-  "64": {
-    "factual_label": "Healthcare > Assisted Living Services",
-    "single_match": {
-      "integrated_category_id": "15004",
-      "integrated_category_label": "Health and Medicine > Assisted Living Service",
-      "is_exact": true
-    }
-  },
-  "65": {
-    "factual_label": "Healthcare > Home Health Care Services",
-    "single_match": {
-      "integrated_category_id": "15012",
-      "integrated_category_label": "Health and Medicine > Home Health Care Service",
-      "is_exact": true
-    }
-  },
-  "66": {
-    "factual_label": "Healthcare > Assisted Living Services > Facilities and Nursing Homes",
-    "single_match": {
-      "integrated_category_id": "15022",
-      "integrated_category_label": "Health and Medicine > Nursing Home",
-      "is_exact": true
-    }
-  },
-  "67": {
-    "factual_label": "Healthcare > Blood Banks and Centers",
-    "single_match": {
-      "integrated_category_id": "15005",
-      "integrated_category_label": "Health and Medicine > Blood Bank",
-      "is_exact": true
-    }
-  },
-  "68": {
-    "factual_label": "Healthcare > Chiropractors",
-    "single_match": {
-      "integrated_category_id": "15006",
-      "integrated_category_label": "Health and Medicine > Chiropractor",
-      "is_exact": true
-    }
-  },
-  "69": {
-    "factual_label": "Healthcare > Dentists",
-    "single_match": {
-      "integrated_category_id": "15007",
-      "integrated_category_label": "Health and Medicine > Dentist",
-      "is_exact": true
-    }
-  },
-  "70": {
-    "factual_label": "Healthcare > Emergency Services",
-    "single_match": {
-      "integrated_category_id": "15008",
-      "integrated_category_label": "Health and Medicine > Emergency Service",
-      "is_exact": true
-    }
-  },
-  "71": {
-    "factual_label": "Healthcare > Emergency Services > Ambulance",
-    "single_match": {
-      "integrated_category_id": "15009",
-      "integrated_category_label": "Health and Medicine > Emergency Service > Ambulance Service",
-      "is_exact": true
-    }
-  },
-  "72": {
-    "factual_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine",
-    "single_match": {
-      "integrated_category_id": "15003",
-      "integrated_category_label": "Health and Medicine > Alternative Medicine Clinic",
-      "is_exact": true
-    }
-  },
-  "73": {
-    "factual_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine > Acupuncture",
-    "single_match": {
-      "integrated_category_id": "15001",
-      "integrated_category_label": "Health and Medicine > Acupuncture Clinic",
-      "is_exact": true
-    }
-  },
-  "74": {
-    "factual_label": "Healthcare > Hospitals, Clinics and Medical Centers",
-    "single_match": {
-      "integrated_category_id": "15000",
-      "integrated_category_label": "Health and Medicine",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "15016",
-        "integrated_category_label": "Health and Medicine > Medical Center",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "15014",
-        "integrated_category_label": "Health and Medicine > Hospital",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "15011",
-        "integrated_category_label": "Health and Medicine > Healthcare Clinic",
-        "is_exact": true
-      }
-    ]
-  },
-  "75": {
-    "factual_label": "Healthcare > Medical Supplies and Labs",
-    "single_match": {
-      "integrated_category_id": "15000",
-      "integrated_category_label": "Health and Medicine",
-      "is_exact": false
-    },
-    "multiple_match": [
-      {
-        "integrated_category_id": "17095",
-        "integrated_category_label": "Retail > Medical Supply Store",
-        "is_exact": true
-      },
-      {
-        "integrated_category_id": "15017",
-        "integrated_category_label": "Health and Medicine > Medical Lab",
-        "is_exact": true
-      }
-    ]
-  },
-  "76": {
-    "factual_label": "Healthcare > Mental Health",
-    "single_match": {
-      "integrated_category_id": "15018",
-      "integrated_category_label": "Health and Medicine > Mental Health Service",
-      "is_exact": true
-    }
-  },
-  "77": {
-    "factual_label": "Healthcare > Mental Health > Counseling and Therapy",
-    "single_match": {
-      "integrated_category_id": "15019",
-      "integrated_category_label": "Health and Medicine > Mental Health Service > Mental Health Clinic",
-      "is_exact": true
-    }
-  },
-  "78": {
-    "factual_label": "Healthcare > Mental Health > Psychologists",
-    "single_match": {
-      "integrated_category_id": "15020",
-      "integrated_category_label": "Health and Medicine > Mental Health Service > Psychologist",
-      "is_exact": true
-    }
-  },
-  "79": {
-    "factual_label": "Healthcare > Nurses",
-    "single_match": {
-      "integrated_category_id": "15021",
-      "integrated_category_label": "Health and Medicine > Nurse",
-      "is_exact": true
-    }
-  },
-  "80": {
-    "factual_label": "Healthcare > Pharmacies",
-    "single_match": {
-      "integrated_category_id": "17035",
-      "integrated_category_label": "Retail > Drugstore",
-      "is_exact": true
-    }
-  },
-  "81": {
-    "factual_label": "Healthcare > Physical Therapy and Rehabilitation",
-    "single_match": {
-      "integrated_category_id": "15026",
-      "integrated_category_label": "Health and Medicine > Physical Therapy Clinic",
-      "is_exact": true
-    }
-  },
-  "82": {
-    "factual_label": "Healthcare > Physical Therapy and Rehabilitation > Sports Medicine",
-    "single_match": {
-      "integrated_category_id": "15052",
-      "integrated_category_label": "Health and Medicine > Sports Medicine Clinic",
-      "is_exact": true
-    }
-  },
-  "83": {
-    "factual_label": "Healthcare > Physicians",
-    "single_match": {
-      "integrated_category_id": "15027",
-      "integrated_category_label": "Health and Medicine > Physician",
-      "is_exact": true
-    }
-  },
-  "84": {
-    "factual_label": "Healthcare > Physicians > Anesthesiologists",
-    "single_match": {
-      "integrated_category_id": "15028",
-      "integrated_category_label": "Health and Medicine > Physician > Anesthesiologist",
-      "is_exact": true
-    }
-  },
-  "85": {
-    "factual_label": "Healthcare > Physicians > Cardiologists",
-    "single_match": {
-      "integrated_category_id": "15029",
-      "integrated_category_label": "Health and Medicine > Physician > Cardiologist",
-      "is_exact": true
-    }
-  },
-  "86": {
-    "factual_label": "Healthcare > Physicians > Dermatologists",
-    "single_match": {
-      "integrated_category_id": "15030",
-      "integrated_category_label": "Health and Medicine > Physician > Dermatologist",
-      "is_exact": true
-    }
-  },
-  "87": {
-    "factual_label": "Healthcare > Physicians > Ear, Nose and Throat",
-    "single_match": {
-      "integrated_category_id": "15032",
-      "integrated_category_label": "Health and Medicine > Physician > Ear, Nose and Throat Doctor",
-      "is_exact": true
-    }
-  },
-  "88": {
-    "factual_label": "Healthcare > Physicians > Family Medicine",
-    "single_match": {
-      "integrated_category_id": "15033",
-      "integrated_category_label": "Health and Medicine > Physician > Family Medicine Doctor",
-      "is_exact": true
-    }
-  },
-  "89": {
-    "factual_label": "Healthcare > Physicians > Gastroenterologists",
-    "single_match": {
-      "integrated_category_id": "15034",
-      "integrated_category_label": "Health and Medicine > Physician > Gastroenterologist",
-      "is_exact": true
-    }
-  },
-  "90": {
-    "factual_label": "Healthcare > Physicians > General Surgery",
-    "single_match": {
-      "integrated_category_id": "15035",
-      "integrated_category_label": "Health and Medicine > Physician > General Surgeon",
-      "is_exact": true
-    }
-  },
-  "91": {
-    "factual_label": "Healthcare > Physicians > Internal Medicine",
-    "single_match": {
-      "integrated_category_id": "15037",
-      "integrated_category_label": "Health and Medicine > Physician > Internal Medicine Doctor",
-      "is_exact": true
-    }
-  },
-  "92": {
-    "factual_label": "Healthcare > Physicians > Neurologists",
-    "single_match": {
-      "integrated_category_id": "15038",
-      "integrated_category_label": "Health and Medicine > Physician > Neurologist",
-      "is_exact": true
-    }
-  },
-  "93": {
-    "factual_label": "Healthcare > Physicians > Obstetricians and Gynecologists",
-    "single_match": {
-      "integrated_category_id": "15039",
-      "integrated_category_label": "Health and Medicine > Physician > Obstetrician Gynecologist (Ob-gyn)",
-      "is_exact": true
-    }
-  },
-  "94": {
-    "factual_label": "Healthcare > Physicians > Oncologists",
-    "single_match": {
-      "integrated_category_id": "15040",
-      "integrated_category_label": "Health and Medicine > Physician > Oncologist",
-      "is_exact": true
-    }
-  },
-  "95": {
-    "factual_label": "Healthcare > Physicians > Ophthalmologists",
-    "single_match": {
-      "integrated_category_id": "15041",
-      "integrated_category_label": "Health and Medicine > Physician > Ophthalmologist",
-      "is_exact": true
-    }
-  },
-  "96": {
-    "factual_label": "Healthcare > Physicians > Orthopedic Surgeons",
-    "single_match": {
-      "integrated_category_id": "15043",
-      "integrated_category_label": "Health and Medicine > Physician > Orthopedic Surgeon",
-      "is_exact": true
-    }
-  },
-  "97": {
-    "factual_label": "Healthcare > Physicians > Pathologists",
-    "single_match": {
-      "integrated_category_id": "15044",
-      "integrated_category_label": "Health and Medicine > Physician > Pathologist",
-      "is_exact": true
-    }
-  },
-  "98": {
-    "factual_label": "Healthcare > Physicians > Pediatricians",
-    "single_match": {
-      "integrated_category_id": "15045",
-      "integrated_category_label": "Health and Medicine > Physician > Pediatrician",
-      "is_exact": true
-    }
-  },
-  "99": {
-    "factual_label": "Healthcare > Physicians > Plastic Surgeons",
-    "single_match": {
-      "integrated_category_id": "15046",
-      "integrated_category_label": "Health and Medicine > Physician > Plastic Surgeon",
       "is_exact": true
     }
   },
@@ -950,6 +87,14 @@
       "is_exact": true
     }
   },
+  "11": {
+    "factual_label": "Automotive > Maintenance and Repair > Smog Check",
+    "single_match": {
+      "integrated_category_id": "11014",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Smog Check Shop",
+      "is_exact": true
+    }
+  },
   "110": {
     "factual_label": "Landmarks > Historic and Protected Sites",
     "single_match": {
@@ -1027,6 +172,14 @@
     "single_match": {
       "integrated_category_id": "16035",
       "integrated_category_label": "Landmarks and Outdoors > Park > Natural Park",
+      "is_exact": true
+    }
+  },
+  "12": {
+    "factual_label": "Automotive > Maintenance and Repair > Tires",
+    "single_match": {
+      "integrated_category_id": "11015",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Tire Repair Shop",
       "is_exact": true
     }
   },
@@ -1110,6 +263,14 @@
       "is_exact": true
     }
   },
+  "13": {
+    "factual_label": "Automotive > Maintenance and Repair > Transmissions",
+    "single_match": {
+      "integrated_category_id": "11017",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Transmissions Shop",
+      "is_exact": true
+    }
+  },
   "130": {
     "factual_label": "Retail > Bookstores",
     "single_match": {
@@ -1190,13 +351,38 @@
       "is_exact": true
     }
   },
+  "14": {
+    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters",
+    "multiple_match": [
+      {
+        "integrated_category_id": "11009",
+        "integrated_category_label": "Business and Professional Services > Automotive Service",
+        "is_exact": false
+      },
+      {
+        "integrated_category_id": "11012",
+        "integrated_category_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "17012",
+        "integrated_category_label": "Retail > Automotive Retail > Motorcycle Dealership",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "17013",
+        "integrated_category_label": "Retail > Automotive Retail > Motorsports Store",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "11009",
+      "integrated_category_label": "Business and Professional Services > Automotive Service",
+      "is_exact": false
+    }
+  },
   "140": {
     "factual_label": "Retail > Dance and Music",
-    "single_match": {
-      "integrated_category_id": "17000",
-      "integrated_category_label": "Retail",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "17032",
@@ -1208,7 +394,12 @@
         "integrated_category_label": "Retail > Music Store",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "17000",
+      "integrated_category_label": "Retail",
+      "is_exact": false
+    }
   },
   "141": {
     "factual_label": "Retail > Department Stores",
@@ -1282,13 +473,16 @@
       "is_exact": true
     }
   },
+  "15": {
+    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters > Repair",
+    "single_match": {
+      "integrated_category_id": "11012",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
+      "is_exact": true
+    }
+  },
   "150": {
     "factual_label": "Retail > Food and Beverage > Beer, Wine and Spirits",
-    "single_match": {
-      "integrated_category_id": "17057",
-      "integrated_category_label": "Retail > Food and Beverage Retail",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "17058",
@@ -1305,7 +499,12 @@
         "integrated_category_label": "Retail > Food and Beverage Retail > Liquor Store",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "17057",
+      "integrated_category_label": "Retail > Food and Beverage Retail",
+      "is_exact": false
+    }
   },
   "151": {
     "factual_label": "Retail > Food and Beverage > Candy Stores",
@@ -1379,6 +578,14 @@
       "is_exact": true
     }
   },
+  "16": {
+    "factual_label": "Automotive > Motorcycles, Mopeds and Scooters > Sales",
+    "single_match": {
+      "integrated_category_id": "17012",
+      "integrated_category_label": "Retail > Automotive Retail > Motorcycle Dealership",
+      "is_exact": true
+    }
+  },
   "160": {
     "factual_label": "Retail > Hobby and Collectibles",
     "single_match": {
@@ -1397,11 +604,6 @@
   },
   "162": {
     "factual_label": "Retail > Music, Video and DVD",
-    "single_match": {
-      "integrated_category_id": "17000",
-      "integrated_category_label": "Retail",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "17098",
@@ -1413,7 +615,12 @@
         "integrated_category_label": "Retail > Video Store",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "17000",
+      "integrated_category_label": "Retail",
+      "is_exact": false
+    }
   },
   "163": {
     "factual_label": "Retail > Newsstands",
@@ -1465,11 +672,6 @@
   },
   "169": {
     "factual_label": "Retail > Shopping Centers and Malls",
-    "single_match": {
-      "integrated_category_id": "17000",
-      "integrated_category_label": "Retail",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "17114",
@@ -1481,7 +683,20 @@
         "integrated_category_label": "Retail > Shopping Plaza",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "17000",
+      "integrated_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17": {
+    "factual_label": "Automotive > RVs and Motor Homes",
+    "single_match": {
+      "integrated_category_id": "17009",
+      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > RV and Motorhome Dealership",
+      "is_exact": true
+    }
   },
   "170": {
     "factual_label": "Retail > Sporting Goods",
@@ -1560,6 +775,14 @@
     "single_match": {
       "integrated_category_id": "11105",
       "integrated_category_label": "Business and Professional Services > Industrial Equipment Supplier",
+      "is_exact": true
+    }
+  },
+  "18": {
+    "factual_label": "Automotive > Salvage Yards",
+    "single_match": {
+      "integrated_category_id": "11160",
+      "integrated_category_label": "Business and Professional Services > Salvage Yard",
       "is_exact": true
     }
   },
@@ -1643,6 +866,14 @@
       "is_exact": true
     }
   },
+  "19": {
+    "factual_label": "Automotive > Towing",
+    "single_match": {
+      "integrated_category_id": "11016",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Towing Service",
+      "is_exact": true
+    }
+  },
   "190": {
     "factual_label": "Businesses and Services > Textiles",
     "single_match": {
@@ -1653,11 +884,6 @@
   },
   "191": {
     "factual_label": "Businesses and Services > Water and Waste Management",
-    "single_match": {
-      "integrated_category_id": "11000",
-      "integrated_category_label": "Business and Professional Services",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11176",
@@ -1679,7 +905,12 @@
         "integrated_category_label": "Business and Professional Services > Recycling Facility",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11000",
+      "integrated_category_label": "Business and Professional Services",
+      "is_exact": false
+    }
   },
   "192": {
     "factual_label": "Businesses and Services > Welding",
@@ -1743,6 +974,34 @@
       "integrated_category_id": "11001",
       "integrated_category_label": "Business and Professional Services > Advertising Agency",
       "is_exact": false
+    }
+  },
+  "2": {
+    "factual_label": "Automotive",
+    "multiple_match": [
+      {
+        "integrated_category_id": "11009",
+        "integrated_category_label": "Business and Professional Services > Automotive Service",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "17005",
+        "integrated_category_label": "Retail > Automotive Retail",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "11000",
+      "integrated_category_label": "Business and Professional Services",
+      "is_exact": false
+    }
+  },
+  "20": {
+    "factual_label": "Community and Government",
+    "single_match": {
+      "integrated_category_id": "12000",
+      "integrated_category_label": "Community and Government",
+      "is_exact": true
     }
   },
   "200": {
@@ -1825,6 +1084,14 @@
       "is_exact": true
     }
   },
+  "21": {
+    "factual_label": "Community and Government > Animal Shelters and Humane Societies",
+    "single_match": {
+      "integrated_category_id": "12002",
+      "integrated_category_label": "Community and Government > Animal Shelter",
+      "is_exact": true
+    }
+  },
   "210": {
     "factual_label": "Businesses and Services > Corporate HQ",
     "single_match": {
@@ -1859,11 +1126,6 @@
   },
   "214": {
     "factual_label": "Businesses and Services > Entertainment",
-    "single_match": {
-      "integrated_category_id": "11000",
-      "integrated_category_label": "Business and Professional Services",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11036",
@@ -1875,7 +1137,12 @@
         "integrated_category_label": "Business and Professional Services > Entertainment Agency",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11000",
+      "integrated_category_label": "Business and Professional Services",
+      "is_exact": false
+    }
   },
   "215": {
     "factual_label": "Businesses and Services > Entertainment > Media",
@@ -1895,11 +1162,6 @@
   },
   "217": {
     "factual_label": "Businesses and Services > Events and Event Planning",
-    "single_match": {
-      "integrated_category_id": "11000",
-      "integrated_category_label": "Business and Professional Services",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11000",
@@ -1921,13 +1183,18 @@
         "integrated_category_label": "Event",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11000",
+      "integrated_category_label": "Business and Professional Services",
+      "is_exact": false
+    }
   },
   "218": {
     "factual_label": "Businesses and Services > Financial > Banking and Finance > ATMs",
     "single_match": {
       "integrated_category_id": "11044",
-      "integrated_category_label": "Business and Professional Services > Financial Service > ATM",
+      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > ATM",
       "is_exact": true
     }
   },
@@ -1936,6 +1203,14 @@
     "single_match": {
       "integrated_category_id": "11042",
       "integrated_category_label": "Business and Professional Services > Financial Service",
+      "is_exact": true
+    }
+  },
+  "22": {
+    "factual_label": "Community and Government > Cemeteries",
+    "single_match": {
+      "integrated_category_id": "12003",
+      "integrated_category_label": "Community and Government > Cemetery",
       "is_exact": true
     }
   },
@@ -2019,6 +1294,26 @@
       "is_exact": false
     }
   },
+  "23": {
+    "factual_label": "Community and Government > Day Care and Preschools",
+    "multiple_match": [
+      {
+        "integrated_category_id": "11026",
+        "integrated_category_label": "Business and Professional Services > Child Care Service > Daycare",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "12056",
+        "integrated_category_label": "Community and Government > Education > Preschool",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "12000",
+      "integrated_category_label": "Community and Government",
+      "is_exact": false
+    }
+  },
   "230": {
     "factual_label": "Businesses and Services > Food and Beverage",
     "single_match": {
@@ -2099,6 +1394,14 @@
       "is_exact": true
     }
   },
+  "24": {
+    "factual_label": "Community and Government > Disabled Persons Services",
+    "single_match": {
+      "integrated_category_id": "12006",
+      "integrated_category_label": "Community and Government > Disabled Persons Service",
+      "is_exact": true
+    }
+  },
   "240": {
     "factual_label": "Businesses and Services > Home Improvement > Contractors > Bathrooms",
     "single_match": {
@@ -2141,11 +1444,6 @@
   },
   "245": {
     "factual_label": "Businesses and Services > Home Improvement > Fences, Fireplaces and Garage Doors",
-    "single_match": {
-      "integrated_category_id": "11076",
-      "integrated_category_label": "Business and Professional Services > Home Improvement Service",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11080",
@@ -2162,7 +1460,12 @@
         "integrated_category_label": "Business and Professional Services > Home Improvement Service > Fence Contractor",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11076",
+      "integrated_category_label": "Business and Professional Services > Home Improvement Service",
+      "is_exact": false
+    }
   },
   "246": {
     "factual_label": "Businesses and Services > Home Improvement > Hardware and Services",
@@ -2193,6 +1496,14 @@
     "single_match": {
       "integrated_category_id": "11088",
       "integrated_category_label": "Business and Professional Services > Home Improvement Service > Home Inspection",
+      "is_exact": true
+    }
+  },
+  "25": {
+    "factual_label": "Community and Government > Drug and Alcohol Services",
+    "single_match": {
+      "integrated_category_id": "12001",
+      "integrated_category_label": "Community and Government > Addiction Treatment Center",
       "is_exact": true
     }
   },
@@ -2276,6 +1587,14 @@
       "is_exact": true
     }
   },
+  "26": {
+    "factual_label": "Community and Government > Education",
+    "single_match": {
+      "integrated_category_id": "12009",
+      "integrated_category_label": "Community and Government > Education",
+      "is_exact": true
+    }
+  },
   "260": {
     "factual_label": "Businesses and Services > Home Improvement > Pools and Spas",
     "single_match": {
@@ -2356,6 +1675,14 @@
       "is_exact": true
     }
   },
+  "27": {
+    "factual_label": "Community and Government > Education > Adult Education",
+    "single_match": {
+      "integrated_category_id": "12010",
+      "integrated_category_label": "Community and Government > Education > Adult Education",
+      "is_exact": true
+    }
+  },
   "270": {
     "factual_label": "Businesses and Services > Legal > Credit Counseling and Bankruptcy Services",
     "single_match": {
@@ -2422,11 +1749,6 @@
   },
   "278": {
     "factual_label": "Businesses and Services > Personal Care > Dry Cleaning, Ironing and Laundry",
-    "single_match": {
-      "integrated_category_id": "11061",
-      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11066",
@@ -2443,7 +1765,12 @@
         "integrated_category_label": "Business and Professional Services > Health and Beauty Service > Laundry Service",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11061",
+      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
+      "is_exact": false
+    }
   },
   "279": {
     "factual_label": "Businesses and Services > Personal Care > Hair Removal",
@@ -2453,13 +1780,16 @@
       "is_exact": true
     }
   },
+  "28": {
+    "factual_label": "Community and Government > Education > Art Lessons and Schools",
+    "single_match": {
+      "integrated_category_id": "12011",
+      "integrated_category_label": "Community and Government > Education > Art School",
+      "is_exact": true
+    }
+  },
   "280": {
     "factual_label": "Businesses and Services > Personal Care > Beauty Salons and Barbers",
-    "single_match": {
-      "integrated_category_id": "11061",
-      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11064",
@@ -2471,7 +1801,12 @@
         "integrated_category_label": "Business and Professional Services > Health and Beauty Service > Barbershop",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11061",
+      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
+      "is_exact": false
+    }
   },
   "281": {
     "factual_label": "Businesses and Services > Personal Care > Manicures and Pedicures",
@@ -2542,6 +1877,14 @@
     "single_match": {
       "integrated_category_id": "11097",
       "integrated_category_label": "Business and Professional Services > Home Improvement Service > Professional Cleaning Service",
+      "is_exact": true
+    }
+  },
+  "29": {
+    "factual_label": "Community and Government > Education > Colleges and Universities",
+    "single_match": {
+      "integrated_category_id": "12013",
+      "integrated_category_label": "Community and Government > Education > College and University",
       "is_exact": true
     }
   },
@@ -2625,6 +1968,22 @@
       "is_exact": true
     }
   },
+  "3": {
+    "factual_label": "Automotive > Car Appraisers",
+    "single_match": {
+      "integrated_category_id": "11009",
+      "integrated_category_label": "Business and Professional Services > Automotive Service",
+      "is_exact": false
+    }
+  },
+  "30": {
+    "factual_label": "Community and Government > Education > Computer Training",
+    "single_match": {
+      "integrated_category_id": "12049",
+      "integrated_category_label": "Community and Government > Education > Computer Training School",
+      "is_exact": true
+    }
+  },
   "300": {
     "factual_label": "Businesses and Services > Real Estate > Corporate Housing",
     "single_match": {
@@ -2705,6 +2064,14 @@
       "is_exact": false
     }
   },
+  "31": {
+    "factual_label": "Community and Government > Education > Culinary Lessons and Schools",
+    "single_match": {
+      "integrated_category_id": "12050",
+      "integrated_category_label": "Community and Government > Education > Culinary School",
+      "is_exact": true
+    }
+  },
   "310": {
     "factual_label": "Social > Arts > Art Dealers and Galleries",
     "single_match": {
@@ -2782,6 +2149,14 @@
     "single_match": {
       "integrated_category_id": "10001",
       "integrated_category_label": "Arts and Entertainment > Amusement Park",
+      "is_exact": true
+    }
+  },
+  "32": {
+    "factual_label": "Community and Government > Education > Driving Schools",
+    "single_match": {
+      "integrated_category_id": "12051",
+      "integrated_category_label": "Community and Government > Education > Driving School",
       "is_exact": true
     }
   },
@@ -2865,6 +2240,26 @@
       "is_exact": true
     }
   },
+  "33": {
+    "factual_label": "Community and Government > Education > Fraternities and Sororities",
+    "multiple_match": [
+      {
+        "integrated_category_id": "12043",
+        "integrated_category_label": "Community and Government > Education > College and University > Fraternity House",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "12046",
+        "integrated_category_label": "Community and Government > Education > College and University > Sorority House",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "12013",
+      "integrated_category_label": "Community and Government > Education > College and University",
+      "is_exact": false
+    }
+  },
   "330": {
     "factual_label": "Social > Entertainment > Karaoke",
     "single_match": {
@@ -2945,6 +2340,14 @@
       "is_exact": true
     }
   },
+  "34": {
+    "factual_label": "Community and Government > Education > Primary and Secondary Schools",
+    "single_match": {
+      "integrated_category_id": "12057",
+      "integrated_category_label": "Community and Government > Education > Primary and Secondary School",
+      "is_exact": true
+    }
+  },
   "340": {
     "factual_label": "Social > Food and Dining > Bakeries",
     "single_match": {
@@ -3021,7 +2424,15 @@
     "factual_label": "Social > Food and Dining > Restaurants > Barbecue",
     "single_match": {
       "integrated_category_id": "13026",
-      "integrated_category_label": "Dining and Drinking > BBQ Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > BBQ Joint",
+      "is_exact": true
+    }
+  },
+  "35": {
+    "factual_label": "Community and Government > Education > Tutoring and Educational Services",
+    "single_match": {
+      "integrated_category_id": "11172",
+      "integrated_category_label": "Business and Professional Services > Tutoring Service",
       "is_exact": true
     }
   },
@@ -3029,7 +2440,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Buffets",
     "single_match": {
       "integrated_category_id": "13030",
-      "integrated_category_label": "Dining and Drinking > Buffet",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Buffet",
       "is_exact": true
     }
   },
@@ -3037,7 +2448,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Burgers",
     "single_match": {
       "integrated_category_id": "13031",
-      "integrated_category_label": "Dining and Drinking > Burger Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Burger Joint",
       "is_exact": true
     }
   },
@@ -3053,7 +2464,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Delis",
     "single_match": {
       "integrated_category_id": "13039",
-      "integrated_category_label": "Dining and Drinking > Deli",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Deli",
       "is_exact": true
     }
   },
@@ -3061,7 +2472,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Diners",
     "single_match": {
       "integrated_category_id": "13049",
-      "integrated_category_label": "Dining and Drinking > Diner",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Diner",
       "is_exact": true
     }
   },
@@ -3105,6 +2516,14 @@
       "is_exact": true
     }
   },
+  "36": {
+    "factual_label": "Community and Government > Education > Vocational Schools",
+    "single_match": {
+      "integrated_category_id": "12063",
+      "integrated_category_label": "Community and Government > Education > Trade School",
+      "is_exact": true
+    }
+  },
   "360": {
     "factual_label": "Social > Food and Dining > Restaurants > Korean",
     "single_match": {
@@ -3133,7 +2552,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Pizza",
     "single_match": {
       "integrated_category_id": "13064",
-      "integrated_category_label": "Dining and Drinking > Pizzeria",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Pizzeria",
       "is_exact": true
     }
   },
@@ -3149,7 +2568,7 @@
     "factual_label": "Social > Food and Dining > Restaurants > Steakhouses",
     "single_match": {
       "integrated_category_id": "13383",
-      "integrated_category_label": "Dining and Drinking > Steakhouse",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Steakhouse",
       "is_exact": true
     }
   },
@@ -3185,13 +2604,16 @@
       "is_exact": true
     }
   },
+  "37": {
+    "factual_label": "Community and Government > Government Departments and Agencies",
+    "single_match": {
+      "integrated_category_id": "12069",
+      "integrated_category_label": "Community and Government > Government Building > Government Department / Agency",
+      "is_exact": true
+    }
+  },
   "370": {
     "factual_label": "Social > Wineries and Vineyards",
-    "single_match": {
-      "integrated_category_id": "13000",
-      "integrated_category_label": "Dining and Drinking",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "13386",
@@ -3203,15 +2625,15 @@
         "integrated_category_label": "Dining and Drinking > Winery",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "13000",
+      "integrated_category_label": "Dining and Drinking",
+      "is_exact": false
+    }
   },
   "371": {
     "factual_label": "Social > Zoos, Aquariums and Wildlife Sanctuaries",
-    "single_match": {
-      "integrated_category_id": "10000",
-      "integrated_category_label": "Arts and Entertainment",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "10056",
@@ -3223,7 +2645,12 @@
         "integrated_category_label": "Arts and Entertainment > Aquarium",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "10000",
+      "integrated_category_label": "Arts and Entertainment",
+      "is_exact": false
+    }
   },
   "372": {
     "factual_label": "Sports and Recreation",
@@ -3275,11 +2702,6 @@
   },
   "378": {
     "factual_label": "Sports and Recreation > Cycling",
-    "single_match": {
-      "integrated_category_id": "18000",
-      "integrated_category_label": "Sports and Recreation",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "18024",
@@ -3296,13 +2718,26 @@
         "integrated_category_label": "Travel and Transportation > Bike Rental",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "18000",
+      "integrated_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
   },
   "379": {
     "factual_label": "Sports and Recreation > Dance",
     "single_match": {
       "integrated_category_id": "18025",
       "integrated_category_label": "Sports and Recreation > Gym and Studio > Dance Studio",
+      "is_exact": true
+    }
+  },
+  "38": {
+    "factual_label": "Community and Government > Government Lobbyists",
+    "single_match": {
+      "integrated_category_id": "12076",
+      "integrated_category_label": "Community and Government > Government Lobbyist",
       "is_exact": true
     }
   },
@@ -3386,6 +2821,14 @@
       "is_exact": true
     }
   },
+  "39": {
+    "factual_label": "Community and Government > Housing Assistance and Shelters",
+    "single_match": {
+      "integrated_category_id": "12077",
+      "integrated_category_label": "Community and Government > Homeless Shelter",
+      "is_exact": true
+    }
+  },
   "390": {
     "factual_label": "Sports and Recreation > Outdoors > Hot Air Balloons",
     "single_match": {
@@ -3396,11 +2839,6 @@
   },
   "391": {
     "factual_label": "Sports and Recreation > Outdoors > Hunting and Fishing",
-    "single_match": {
-      "integrated_category_id": "18000",
-      "integrated_category_label": "Sports and Recreation",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "17124",
@@ -3412,7 +2850,12 @@
         "integrated_category_label": "Retail > Sporting Goods Retail > Fishing Store",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "18000",
+      "integrated_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
   },
   "392": {
     "factual_label": "Sports and Recreation > Outdoors > Rock Climbing",
@@ -3475,6 +2918,22 @@
     "single_match": {
       "integrated_category_id": "18045",
       "integrated_category_label": "Sports and Recreation > Racquet Sports > Tennis",
+      "is_exact": true
+    }
+  },
+  "4": {
+    "factual_label": "Automotive > Car Dealers and Leasing",
+    "single_match": {
+      "integrated_category_id": "17006",
+      "integrated_category_label": "Retail > Automotive Retail > Car Dealership",
+      "is_exact": true
+    }
+  },
+  "40": {
+    "factual_label": "Community and Government > Law Enforcement and Public Safety",
+    "single_match": {
+      "integrated_category_id": "12070",
+      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety",
       "is_exact": true
     }
   },
@@ -3552,11 +3011,6 @@
   },
   "409": {
     "factual_label": "Sports and Recreation > Water Sports > Boating",
-    "single_match": {
-      "integrated_category_id": "18067",
-      "integrated_category_label": "Sports and Recreation > Water Sports",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "18070",
@@ -3568,7 +3022,20 @@
         "integrated_category_label": "Travel and Transportation > Boat Rental",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "18067",
+      "integrated_category_label": "Sports and Recreation > Water Sports",
+      "is_exact": false
+    }
+  },
+  "41": {
+    "factual_label": "Community and Government > Law Enforcement and Public Safety > Rescue Services",
+    "single_match": {
+      "integrated_category_id": "15008",
+      "integrated_category_label": "Health and Medicine > Emergency Service",
+      "is_exact": false
+    }
   },
   "410": {
     "factual_label": "Sports and Recreation > Water Sports > Canoes and Kayaks",
@@ -3604,11 +3071,6 @@
   },
   "414": {
     "factual_label": "Sports and Recreation > Yoga and Pilates",
-    "single_match": {
-      "integrated_category_id": "18021",
-      "integrated_category_label": "Sports and Recreation > Gym and Studio",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "18028",
@@ -3620,7 +3082,12 @@
         "integrated_category_label": "Sports and Recreation > Gym and Studio > Pilates Studio",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "18021",
+      "integrated_category_label": "Sports and Recreation > Gym and Studio",
+      "is_exact": false
+    }
   },
   "415": {
     "factual_label": "Transportation",
@@ -3659,6 +3126,14 @@
     "single_match": {
       "integrated_category_id": "19054",
       "integrated_category_label": "Travel and Transportation > Transportation Service > Public Transportation",
+      "is_exact": true
+    }
+  },
+  "42": {
+    "factual_label": "Community and Government > Law Enforcement and Public Safety > Fire Stations",
+    "single_match": {
+      "integrated_category_id": "12071",
+      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Fire Station",
       "is_exact": true
     }
   },
@@ -3742,6 +3217,14 @@
       "is_exact": true
     }
   },
+  "43": {
+    "factual_label": "Community and Government > Law Enforcement and Public Safety > Police Stations",
+    "single_match": {
+      "integrated_category_id": "12072",
+      "integrated_category_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Police Station",
+      "is_exact": true
+    }
+  },
   "430": {
     "factual_label": "Travel",
     "single_match": {
@@ -3792,11 +3275,6 @@
   },
   "436": {
     "factual_label": "Travel > Lodging > Hotels and Motels",
-    "single_match": {
-      "integrated_category_id": "19009",
-      "integrated_category_label": "Travel and Transportation > Lodging",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "19014",
@@ -3808,7 +3286,12 @@
         "integrated_category_label": "Travel and Transportation > Lodging > Motel",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "19009",
+      "integrated_category_label": "Travel and Transportation > Lodging",
+      "is_exact": false
+    }
   },
   "437": {
     "factual_label": "Travel > Lodging > Lodges and Vacation Rentals",
@@ -3834,13 +3317,16 @@
       "is_exact": true
     }
   },
+  "44": {
+    "factual_label": "Community and Government > Libraries",
+    "single_match": {
+      "integrated_category_id": "12080",
+      "integrated_category_label": "Community and Government > Library",
+      "is_exact": true
+    }
+  },
   "440": {
     "factual_label": "Travel > Travel Agents and Tour Operators",
-    "single_match": {
-      "integrated_category_id": "19000",
-      "integrated_category_label": "Travel and Transportation",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "19055",
@@ -3852,7 +3338,12 @@
         "integrated_category_label": "Travel and Transportation > Tourist Information and Service > Tour Provider",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "19000",
+      "integrated_category_label": "Travel and Transportation",
+      "is_exact": false
+    }
   },
   "441": {
     "factual_label": "Healthcare > Physicians > Geriatrics",
@@ -3923,6 +3414,14 @@
     "single_match": {
       "integrated_category_id": "11137",
       "integrated_category_label": "Business and Professional Services > Photography Service",
+      "is_exact": true
+    }
+  },
+  "45": {
+    "factual_label": "Community and Government > Military",
+    "single_match": {
+      "integrated_category_id": "12073",
+      "integrated_category_label": "Community and Government > Government Building > Military",
       "is_exact": true
     }
   },
@@ -4006,6 +3505,14 @@
       "is_exact": true
     }
   },
+  "46": {
+    "factual_label": "Community and Government > Military > Bases",
+    "single_match": {
+      "integrated_category_id": "12074",
+      "integrated_category_label": "Community and Government > Government Building > Military > Military Base",
+      "is_exact": true
+    }
+  },
   "460": {
     "factual_label": "Businesses and Services > Technology",
     "single_match": {
@@ -4078,6 +3585,14 @@
       "is_exact": true
     }
   },
+  "47": {
+    "factual_label": "Community and Government > Organizations and Associations",
+    "single_match": {
+      "integrated_category_id": "12082",
+      "integrated_category_label": "Community and Government > Organization",
+      "is_exact": true
+    }
+  },
   "470": {
     "factual_label": "Retail > Pets > Grooming",
     "single_match": {
@@ -4104,23 +3619,23 @@
   },
   "473": {
     "factual_label": "Businesses and Services > Financial > Banking and Finance > Banks and Credit Unions",
-    "single_match": {
-      "integrated_category_id": "11046",
-      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11051",
-        "integrated_category_label": "Business and Professional Services > Financial Service > Credit Union",
+        "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > Credit Union",
         "is_exact": true
       },
       {
         "integrated_category_id": "11045",
-        "integrated_category_label": "Business and Professional Services > Financial Service > Bank",
+        "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > Bank",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11046",
+      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance",
+      "is_exact": false
+    }
   },
   "474": {
     "factual_label": "Businesses and Services > Legal > Attorneys and Law Offices",
@@ -4170,6 +3685,14 @@
       "is_exact": true
     }
   },
+  "48": {
+    "factual_label": "Community and Government > Organizations and Associations > Charities and Non-Profits",
+    "single_match": {
+      "integrated_category_id": "12083",
+      "integrated_category_label": "Community and Government > Organization > Charity",
+      "is_exact": true
+    }
+  },
   "480": {
     "factual_label": "Retail > Comic Book Stores",
     "single_match": {
@@ -4207,6 +3730,483 @@
     "single_match": {
       "integrated_category_id": "17021",
       "integrated_category_label": "Retail > Cannabis Store",
+      "is_exact": true
+    }
+  },
+  "49": {
+    "factual_label": "Community and Government > Organizations and Associations > Environmental",
+    "single_match": {
+      "integrated_category_id": "12085",
+      "integrated_category_label": "Community and Government > Organization > Environmental Organization",
+      "is_exact": true
+    }
+  },
+  "5": {
+    "factual_label": "Automotive > Car Dealers and Leasing > Used Cars",
+    "single_match": {
+      "integrated_category_id": "17010",
+      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > Used Car Dealership",
+      "is_exact": true
+    }
+  },
+  "50": {
+    "factual_label": "Community and Government > Organizations and Associations > Youth Organizations",
+    "single_match": {
+      "integrated_category_id": "12089",
+      "integrated_category_label": "Community and Government > Organization > Youth Organization",
+      "is_exact": true
+    }
+  },
+  "51": {
+    "factual_label": "Community and Government > Post Offices",
+    "single_match": {
+      "integrated_category_id": "12075",
+      "integrated_category_label": "Community and Government > Government Building > Post Office",
+      "is_exact": true
+    }
+  },
+  "52": {
+    "factual_label": "Community and Government > Public and Social Services",
+    "single_match": {
+      "integrated_category_id": "12091",
+      "integrated_category_label": "Community and Government > Public and Social Service",
+      "is_exact": true
+    }
+  },
+  "53": {
+    "factual_label": "Community and Government > Religious",
+    "single_match": {
+      "integrated_category_id": "12098",
+      "integrated_category_label": "Community and Government > Spiritual Center",
+      "is_exact": true
+    }
+  },
+  "54": {
+    "factual_label": "Community and Government > Religious > Buddhist Temples",
+    "single_match": {
+      "integrated_category_id": "12099",
+      "integrated_category_label": "Community and Government > Spiritual Center > Buddhist Temple",
+      "is_exact": true
+    }
+  },
+  "55": {
+    "factual_label": "Community and Government > Religious > Churches",
+    "single_match": {
+      "integrated_category_id": "12101",
+      "integrated_category_label": "Community and Government > Spiritual Center > Church",
+      "is_exact": true
+    }
+  },
+  "56": {
+    "factual_label": "Community and Government > Religious > Hindu Temples",
+    "single_match": {
+      "integrated_category_id": "12103",
+      "integrated_category_label": "Community and Government > Spiritual Center > Hindu Temple",
+      "is_exact": true
+    }
+  },
+  "57": {
+    "factual_label": "Community and Government > Religious > Mosques",
+    "single_match": {
+      "integrated_category_id": "12106",
+      "integrated_category_label": "Community and Government > Spiritual Center > Mosque",
+      "is_exact": true
+    }
+  },
+  "58": {
+    "factual_label": "Community and Government > Religious > Synagogues",
+    "single_match": {
+      "integrated_category_id": "12110",
+      "integrated_category_label": "Community and Government > Spiritual Center > Synagogue",
+      "is_exact": true
+    }
+  },
+  "59": {
+    "factual_label": "Community and Government > Senior Citizen Services",
+    "single_match": {
+      "integrated_category_id": "12096",
+      "integrated_category_label": "Community and Government > Senior Citizen Service",
+      "is_exact": true
+    }
+  },
+  "6": {
+    "factual_label": "Automotive > Car Parts and Accessories",
+    "single_match": {
+      "integrated_category_id": "17011",
+      "integrated_category_label": "Retail > Automotive Retail > Car Parts and Accessories",
+      "is_exact": true
+    }
+  },
+  "60": {
+    "factual_label": "Community and Government > Senior Citizen Services > Retirement",
+    "single_match": {
+      "integrated_category_id": "12095",
+      "integrated_category_label": "Community and Government > Retirement Home",
+      "is_exact": true
+    }
+  },
+  "61": {
+    "factual_label": "Community and Government > Utility Companies",
+    "single_match": {
+      "integrated_category_id": "12115",
+      "integrated_category_label": "Community and Government > Utility Company",
+      "is_exact": true
+    }
+  },
+  "62": {
+    "factual_label": "Healthcare",
+    "single_match": {
+      "integrated_category_id": "15000",
+      "integrated_category_label": "Health and Medicine",
+      "is_exact": true
+    }
+  },
+  "63": {
+    "factual_label": "Healthcare > AIDS Resources",
+    "single_match": {
+      "integrated_category_id": "15002",
+      "integrated_category_label": "Health and Medicine > AIDS Resource",
+      "is_exact": true
+    }
+  },
+  "64": {
+    "factual_label": "Healthcare > Assisted Living Services",
+    "single_match": {
+      "integrated_category_id": "15004",
+      "integrated_category_label": "Health and Medicine > Assisted Living Service",
+      "is_exact": true
+    }
+  },
+  "65": {
+    "factual_label": "Healthcare > Home Health Care Services",
+    "single_match": {
+      "integrated_category_id": "15012",
+      "integrated_category_label": "Health and Medicine > Home Health Care Service",
+      "is_exact": true
+    }
+  },
+  "66": {
+    "factual_label": "Healthcare > Assisted Living Services > Facilities and Nursing Homes",
+    "single_match": {
+      "integrated_category_id": "15022",
+      "integrated_category_label": "Health and Medicine > Nursing Home",
+      "is_exact": true
+    }
+  },
+  "67": {
+    "factual_label": "Healthcare > Blood Banks and Centers",
+    "single_match": {
+      "integrated_category_id": "15005",
+      "integrated_category_label": "Health and Medicine > Blood Bank",
+      "is_exact": true
+    }
+  },
+  "68": {
+    "factual_label": "Healthcare > Chiropractors",
+    "single_match": {
+      "integrated_category_id": "15006",
+      "integrated_category_label": "Health and Medicine > Chiropractor",
+      "is_exact": true
+    }
+  },
+  "69": {
+    "factual_label": "Healthcare > Dentists",
+    "single_match": {
+      "integrated_category_id": "15007",
+      "integrated_category_label": "Health and Medicine > Dentist",
+      "is_exact": true
+    }
+  },
+  "7": {
+    "factual_label": "Automotive > Car Wash and Detail",
+    "single_match": {
+      "integrated_category_id": "11011",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Car Wash and Detail",
+      "is_exact": true
+    }
+  },
+  "70": {
+    "factual_label": "Healthcare > Emergency Services",
+    "single_match": {
+      "integrated_category_id": "15008",
+      "integrated_category_label": "Health and Medicine > Emergency Service",
+      "is_exact": true
+    }
+  },
+  "71": {
+    "factual_label": "Healthcare > Emergency Services > Ambulance",
+    "single_match": {
+      "integrated_category_id": "15009",
+      "integrated_category_label": "Health and Medicine > Emergency Service > Ambulance Service",
+      "is_exact": true
+    }
+  },
+  "72": {
+    "factual_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine",
+    "single_match": {
+      "integrated_category_id": "15003",
+      "integrated_category_label": "Health and Medicine > Alternative Medicine Clinic",
+      "is_exact": true
+    }
+  },
+  "73": {
+    "factual_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine > Acupuncture",
+    "single_match": {
+      "integrated_category_id": "15001",
+      "integrated_category_label": "Health and Medicine > Acupuncture Clinic",
+      "is_exact": true
+    }
+  },
+  "74": {
+    "factual_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+    "multiple_match": [
+      {
+        "integrated_category_id": "15016",
+        "integrated_category_label": "Health and Medicine > Medical Center",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "15014",
+        "integrated_category_label": "Health and Medicine > Hospital",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "15011",
+        "integrated_category_label": "Health and Medicine > Healthcare Clinic",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "15000",
+      "integrated_category_label": "Health and Medicine",
+      "is_exact": false
+    }
+  },
+  "75": {
+    "factual_label": "Healthcare > Medical Supplies and Labs",
+    "multiple_match": [
+      {
+        "integrated_category_id": "17095",
+        "integrated_category_label": "Retail > Medical Supply Store",
+        "is_exact": true
+      },
+      {
+        "integrated_category_id": "15017",
+        "integrated_category_label": "Health and Medicine > Medical Lab",
+        "is_exact": true
+      }
+    ],
+    "single_match": {
+      "integrated_category_id": "15000",
+      "integrated_category_label": "Health and Medicine",
+      "is_exact": false
+    }
+  },
+  "76": {
+    "factual_label": "Healthcare > Mental Health",
+    "single_match": {
+      "integrated_category_id": "15018",
+      "integrated_category_label": "Health and Medicine > Mental Health Service",
+      "is_exact": true
+    }
+  },
+  "77": {
+    "factual_label": "Healthcare > Mental Health > Counseling and Therapy",
+    "single_match": {
+      "integrated_category_id": "15019",
+      "integrated_category_label": "Health and Medicine > Mental Health Service > Mental Health Clinic",
+      "is_exact": true
+    }
+  },
+  "78": {
+    "factual_label": "Healthcare > Mental Health > Psychologists",
+    "single_match": {
+      "integrated_category_id": "15020",
+      "integrated_category_label": "Health and Medicine > Mental Health Service > Psychologist",
+      "is_exact": true
+    }
+  },
+  "79": {
+    "factual_label": "Healthcare > Nurses",
+    "single_match": {
+      "integrated_category_id": "15021",
+      "integrated_category_label": "Health and Medicine > Nurse",
+      "is_exact": true
+    }
+  },
+  "8": {
+    "factual_label": "Automotive > Classic and Antique Car",
+    "single_match": {
+      "integrated_category_id": "17007",
+      "integrated_category_label": "Retail > Automotive Retail > Car Dealership > Classic and Antique Car Dealership",
+      "is_exact": true
+    }
+  },
+  "80": {
+    "factual_label": "Healthcare > Pharmacies",
+    "single_match": {
+      "integrated_category_id": "17035",
+      "integrated_category_label": "Retail > Drugstore",
+      "is_exact": true
+    }
+  },
+  "81": {
+    "factual_label": "Healthcare > Physical Therapy and Rehabilitation",
+    "single_match": {
+      "integrated_category_id": "15026",
+      "integrated_category_label": "Health and Medicine > Physical Therapy Clinic",
+      "is_exact": true
+    }
+  },
+  "82": {
+    "factual_label": "Healthcare > Physical Therapy and Rehabilitation > Sports Medicine",
+    "single_match": {
+      "integrated_category_id": "15052",
+      "integrated_category_label": "Health and Medicine > Sports Medicine Clinic",
+      "is_exact": true
+    }
+  },
+  "83": {
+    "factual_label": "Healthcare > Physicians",
+    "single_match": {
+      "integrated_category_id": "15027",
+      "integrated_category_label": "Health and Medicine > Physician",
+      "is_exact": true
+    }
+  },
+  "84": {
+    "factual_label": "Healthcare > Physicians > Anesthesiologists",
+    "single_match": {
+      "integrated_category_id": "15028",
+      "integrated_category_label": "Health and Medicine > Physician > Anesthesiologist",
+      "is_exact": true
+    }
+  },
+  "85": {
+    "factual_label": "Healthcare > Physicians > Cardiologists",
+    "single_match": {
+      "integrated_category_id": "15029",
+      "integrated_category_label": "Health and Medicine > Physician > Cardiologist",
+      "is_exact": true
+    }
+  },
+  "86": {
+    "factual_label": "Healthcare > Physicians > Dermatologists",
+    "single_match": {
+      "integrated_category_id": "15030",
+      "integrated_category_label": "Health and Medicine > Physician > Dermatologist",
+      "is_exact": true
+    }
+  },
+  "87": {
+    "factual_label": "Healthcare > Physicians > Ear, Nose and Throat",
+    "single_match": {
+      "integrated_category_id": "15032",
+      "integrated_category_label": "Health and Medicine > Physician > Ear, Nose and Throat Doctor",
+      "is_exact": true
+    }
+  },
+  "88": {
+    "factual_label": "Healthcare > Physicians > Family Medicine",
+    "single_match": {
+      "integrated_category_id": "15033",
+      "integrated_category_label": "Health and Medicine > Physician > Family Medicine Doctor",
+      "is_exact": true
+    }
+  },
+  "89": {
+    "factual_label": "Healthcare > Physicians > Gastroenterologists",
+    "single_match": {
+      "integrated_category_id": "15034",
+      "integrated_category_label": "Health and Medicine > Physician > Gastroenterologist",
+      "is_exact": true
+    }
+  },
+  "9": {
+    "factual_label": "Automotive > Maintenance and Repair",
+    "single_match": {
+      "integrated_category_id": "11010",
+      "integrated_category_label": "Business and Professional Services > Automotive Service > Automotive Repair Shop",
+      "is_exact": true
+    }
+  },
+  "90": {
+    "factual_label": "Healthcare > Physicians > General Surgery",
+    "single_match": {
+      "integrated_category_id": "15035",
+      "integrated_category_label": "Health and Medicine > Physician > General Surgeon",
+      "is_exact": true
+    }
+  },
+  "91": {
+    "factual_label": "Healthcare > Physicians > Internal Medicine",
+    "single_match": {
+      "integrated_category_id": "15037",
+      "integrated_category_label": "Health and Medicine > Physician > Internal Medicine Doctor",
+      "is_exact": true
+    }
+  },
+  "92": {
+    "factual_label": "Healthcare > Physicians > Neurologists",
+    "single_match": {
+      "integrated_category_id": "15038",
+      "integrated_category_label": "Health and Medicine > Physician > Neurologist",
+      "is_exact": true
+    }
+  },
+  "93": {
+    "factual_label": "Healthcare > Physicians > Obstetricians and Gynecologists",
+    "single_match": {
+      "integrated_category_id": "15039",
+      "integrated_category_label": "Health and Medicine > Physician > Obstetrician Gynecologist (Ob-gyn)",
+      "is_exact": true
+    }
+  },
+  "94": {
+    "factual_label": "Healthcare > Physicians > Oncologists",
+    "single_match": {
+      "integrated_category_id": "15040",
+      "integrated_category_label": "Health and Medicine > Physician > Oncologist",
+      "is_exact": true
+    }
+  },
+  "95": {
+    "factual_label": "Healthcare > Physicians > Ophthalmologists",
+    "single_match": {
+      "integrated_category_id": "15041",
+      "integrated_category_label": "Health and Medicine > Physician > Ophthalmologist",
+      "is_exact": true
+    }
+  },
+  "96": {
+    "factual_label": "Healthcare > Physicians > Orthopedic Surgeons",
+    "single_match": {
+      "integrated_category_id": "15043",
+      "integrated_category_label": "Health and Medicine > Physician > Orthopedic Surgeon",
+      "is_exact": true
+    }
+  },
+  "97": {
+    "factual_label": "Healthcare > Physicians > Pathologists",
+    "single_match": {
+      "integrated_category_id": "15044",
+      "integrated_category_label": "Health and Medicine > Physician > Pathologist",
+      "is_exact": true
+    }
+  },
+  "98": {
+    "factual_label": "Healthcare > Physicians > Pediatricians",
+    "single_match": {
+      "integrated_category_id": "15045",
+      "integrated_category_label": "Health and Medicine > Physician > Pediatrician",
+      "is_exact": true
+    }
+  },
+  "99": {
+    "factual_label": "Healthcare > Physicians > Plastic Surgeons",
+    "single_match": {
+      "integrated_category_id": "15046",
+      "integrated_category_label": "Health and Medicine > Physician > Plastic Surgeon",
       "is_exact": true
     }
   }

--- a/categories/integrated_places_files/foursquare_to_integrated.json
+++ b/categories/integrated_places_files/foursquare_to_integrated.json
@@ -171,7 +171,7 @@
     "foursquare_label": "Shop & Service > Bank",
     "single_match": {
       "integrated_category_id": "11045",
-      "integrated_category_label": "Business and Professional Services > Financial Service > Bank",
+      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > Bank",
       "is_exact": true
     }
   },
@@ -265,11 +265,6 @@
   },
   "4bf58dd8d48988d110951735": {
     "foursquare_label": "Shop & Service > Salon / Barbershop",
-    "single_match": {
-      "integrated_category_id": "11061",
-      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11064",
@@ -281,7 +276,12 @@
         "integrated_category_label": "Business and Professional Services > Health and Beauty Service > Barbershop",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11061",
+      "integrated_category_label": "Business and Professional Services > Health and Beauty Service",
+      "is_exact": false
+    }
   },
   "4bf58dd8d48988d111941735": {
     "foursquare_label": "Food > Asian Restaurant > Japanese Restaurant",
@@ -903,7 +903,7 @@
     "foursquare_label": "Food > Deli / Bodega",
     "single_match": {
       "integrated_category_id": "13039",
-      "integrated_category_label": "Dining and Drinking > Deli",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Deli",
       "is_exact": true
     }
   },
@@ -911,7 +911,7 @@
     "foursquare_label": "Food > Diner",
     "single_match": {
       "integrated_category_id": "13049",
-      "integrated_category_label": "Dining and Drinking > Diner",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Diner",
       "is_exact": true
     }
   },
@@ -951,7 +951,7 @@
     "foursquare_label": "Food > Wings Joint",
     "single_match": {
       "integrated_category_id": "13388",
-      "integrated_category_label": "Dining and Drinking > Wings Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Wings Joint",
       "is_exact": true
     }
   },
@@ -1023,7 +1023,7 @@
     "foursquare_label": "Food > Gastropub",
     "single_match": {
       "integrated_category_id": "13057",
-      "integrated_category_label": "Dining and Drinking > Gastropub",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Gastropub",
       "is_exact": true
     }
   },
@@ -1207,7 +1207,7 @@
     "foursquare_label": "Food > Burger Joint",
     "single_match": {
       "integrated_category_id": "13031",
-      "integrated_category_label": "Dining and Drinking > Burger Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Burger Joint",
       "is_exact": true
     }
   },
@@ -1231,7 +1231,7 @@
     "foursquare_label": "Food > Hot Dog Joint",
     "single_match": {
       "integrated_category_id": "13058",
-      "integrated_category_label": "Dining and Drinking > Hot Dog Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Hot Dog Joint",
       "is_exact": true
     }
   },
@@ -1607,7 +1607,7 @@
     "foursquare_label": "College & University > Community College",
     "single_match": {
       "integrated_category_id": "12048",
-      "integrated_category_label": "Community and Government > Education > Community College",
+      "integrated_category_label": "Community and Government > Education > College and University > Community College",
       "is_exact": true
     }
   },
@@ -1688,6 +1688,14 @@
     "single_match": {
       "integrated_category_id": "12063",
       "integrated_category_label": "Community and Government > Education > Trade School",
+      "is_exact": true
+    }
+  },
+  "4bf58dd8d48988d1ae941735": {
+    "foursquare_label": "College & University > University",
+    "single_match": {
+      "integrated_category_id": "12013",
+      "integrated_category_label": "Community and Government > Education > College and University",
       "is_exact": true
     }
   },
@@ -1823,7 +1831,7 @@
     "foursquare_label": "Food > Mac & Cheese Joint",
     "single_match": {
       "integrated_category_id": "13060",
-      "integrated_category_label": "Dining and Drinking > Mac and Cheese Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Mac and Cheese Joint",
       "is_exact": true
     }
   },
@@ -1911,7 +1919,7 @@
     "foursquare_label": "Food > Pizza Place",
     "single_match": {
       "integrated_category_id": "13064",
-      "integrated_category_label": "Dining and Drinking > Pizzeria",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Pizzeria",
       "is_exact": true
     }
   },
@@ -1927,7 +1935,7 @@
     "foursquare_label": "Food > Steakhouse",
     "single_match": {
       "integrated_category_id": "13383",
-      "integrated_category_label": "Dining and Drinking > Steakhouse",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Steakhouse",
       "is_exact": true
     }
   },
@@ -2055,7 +2063,7 @@
     "foursquare_label": "Food > BBQ Joint",
     "single_match": {
       "integrated_category_id": "13026",
-      "integrated_category_label": "Dining and Drinking > BBQ Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > BBQ Joint",
       "is_exact": true
     }
   },
@@ -2591,7 +2599,7 @@
     "foursquare_label": "Food > Fried Chicken Joint",
     "single_match": {
       "integrated_category_id": "13055",
-      "integrated_category_label": "Dining and Drinking > Fried Chicken Joint",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Fried Chicken Joint",
       "is_exact": true
     }
   },
@@ -2943,7 +2951,7 @@
     "foursquare_label": "Food > Fish & Chips Shop",
     "single_match": {
       "integrated_category_id": "13051",
-      "integrated_category_label": "Dining and Drinking > Fish and Chips Shop",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Fish and Chips Shop",
       "is_exact": true
     }
   },
@@ -3215,7 +3223,7 @@
     "foursquare_label": "Shop & Service > Credit Union",
     "single_match": {
       "integrated_category_id": "11051",
-      "integrated_category_label": "Business and Professional Services > Financial Service > Credit Union",
+      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > Credit Union",
       "is_exact": true
     }
   },
@@ -3237,11 +3245,6 @@
   },
   "503287a291d4c4b30a586d65": {
     "foursquare_label": "Shop & Service > Financial or Legal Service",
-    "single_match": {
-      "integrated_category_id": "11000",
-      "integrated_category_label": "Business and Professional Services",
-      "is_exact": false
-    },
     "multiple_match": [
       {
         "integrated_category_id": "11042",
@@ -3253,7 +3256,12 @@
         "integrated_category_label": "Business and Professional Services > Legal Service",
         "is_exact": true
       }
-    ]
+    ],
+    "single_match": {
+      "integrated_category_id": "11000",
+      "integrated_category_label": "Business and Professional Services",
+      "is_exact": false
+    }
   },
   "5032885091d4c4b30a586d66": {
     "foursquare_label": "Shop & Service > Real Estate Office",
@@ -4083,7 +4091,7 @@
     "foursquare_label": "Food > Bistro",
     "single_match": {
       "integrated_category_id": "13027",
-      "integrated_category_label": "Dining and Drinking > Bistro",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Bistro",
       "is_exact": true
     }
   },
@@ -4107,7 +4115,7 @@
     "foursquare_label": "Food > Buffet",
     "single_match": {
       "integrated_category_id": "13030",
-      "integrated_category_label": "Dining and Drinking > Buffet",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Buffet",
       "is_exact": true
     }
   },
@@ -4971,7 +4979,7 @@
     "foursquare_label": "Shop & Service > IT Services",
     "single_match": {
       "integrated_category_id": "11108",
-      "integrated_category_label": "Business and Professional Services > IT Service",
+      "integrated_category_label": "Business and Professional Services > Technology Business > IT Service",
       "is_exact": true
     }
   },
@@ -5211,7 +5219,7 @@
     "foursquare_label": "Shop & Service > ATM",
     "single_match": {
       "integrated_category_id": "11044",
-      "integrated_category_label": "Business and Professional Services > Financial Service > ATM",
+      "integrated_category_label": "Business and Professional Services > Financial Service > Banking and Finance > ATM",
       "is_exact": true
     }
   },
@@ -5499,7 +5507,7 @@
     "foursquare_label": "Food > Indian Restaurant > Indian Sweet Shop",
     "single_match": {
       "integrated_category_id": "13210",
-      "integrated_category_label": "Dining and Drinking > Restaurant > Indian Sweet Shop",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Indian Restaurant > Indian Sweet Shop",
       "is_exact": true
     }
   },
@@ -6115,7 +6123,7 @@
     "foursquare_label": "Food > Friterie",
     "single_match": {
       "integrated_category_id": "13056",
-      "integrated_category_label": "Dining and Drinking > Friterie",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Friterie",
       "is_exact": true
     }
   },
@@ -6355,7 +6363,7 @@
     "foursquare_label": "Food > Pet Café",
     "single_match": {
       "integrated_category_id": "13063",
-      "integrated_category_label": "Dining and Drinking > Pet Café",
+      "integrated_category_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Pet Café",
       "is_exact": true
     }
   },
@@ -6778,8 +6786,8 @@
   "5744ccdfe4b0c0459246b4a8": {
     "foursquare_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Tabbakhi",
     "single_match": {
-      "integrated_category_id": "13384",
-      "integrated_category_label": "Dining and Drinking > Tabbakhi",
+      "integrated_category_id": "13321",
+      "integrated_category_label": "Dining and Drinking > Restaurant > Persian Restaurant > Jegaraki",
       "is_exact": true
     }
   },
@@ -7733,6 +7741,38 @@
       "integrated_category_id": "12088",
       "integrated_category_label": "Community and Government > Organization > Veterans' Organization",
       "is_exact": true
+    }
+  },
+  "5fabfc8099ce226e27fe6b0d": {
+    "foursquare_label": "Outdoors & Recreation > Boat Launch",
+    "single_match": {
+      "integrated_category_id": "16018",
+      "integrated_category_label": "Landmarks and Outdoors > Harbor / Marina",
+      "is_exact": false
+    }
+  },
+  "5fabfe3599ce226e27fe709a": {
+    "foursquare_label": "Outdoors & Recreation > Picnic Area",
+    "single_match": {
+      "integrated_category_id": "16036",
+      "integrated_category_label": "Landmarks and Outdoors > Park > Picnic Area",
+      "is_exact": true
+    }
+  },
+  "5fac002599ce226e27fe72e5": {
+    "foursquare_label": "Professional & Other Places > Architecture Firm",
+    "single_match": {
+      "integrated_category_id": "11003",
+      "integrated_category_label": "Business and Professional Services > Architecture Firm",
+      "is_exact": true
+    }
+  },
+  "5fac018b99ce226e27fe7573": {
+    "foursquare_label": "Outdoors & Recreation > Dam",
+    "single_match": {
+      "integrated_category_id": "16007",
+      "integrated_category_label": "Landmarks and Outdoors > Building / Structure",
+      "is_exact": false
     }
   }
 }

--- a/categories/integrated_places_files/foursquare_to_integrated.json
+++ b/categories/integrated_places_files/foursquare_to_integrated.json
@@ -7767,6 +7767,14 @@
       "is_exact": true
     }
   },
+  "5fac010d99ce226e27fe7467": {
+    "foursquare_label": "Outdoors & Recreation > Picnic Shelter",
+    "single_match": {
+      "integrated_category_id": "16036",
+      "integrated_category_label": "Landmarks and Outdoors > Park > Picnic Area",
+      "is_exact": false
+    }
+  },
   "5fac018b99ce226e27fe7573": {
     "foursquare_label": "Outdoors & Recreation > Dam",
     "single_match": {

--- a/categories/integrated_places_files/integrated_to_factual.json
+++ b/categories/integrated_places_files/integrated_to_factual.json
@@ -1,0 +1,9162 @@
+{
+  "10000": {
+    "integrated_label": "Arts and Entertainment",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": true
+    }
+  },
+  "10001": {
+    "integrated_label": "Arts and Entertainment > Amusement Park",
+    "single_match": {
+      "factual_category_id": "319",
+      "factual_category_label": "Social > Entertainment > Amusement Parks",
+      "is_exact": true
+    }
+  },
+  "10002": {
+    "integrated_label": "Arts and Entertainment > Aquarium",
+    "single_match": {
+      "factual_category_id": "371",
+      "factual_category_label": "Social > Zoos, Aquariums and Wildlife Sanctuaries",
+      "is_exact": false
+    }
+  },
+  "10003": {
+    "integrated_label": "Arts and Entertainment > Arcade",
+    "single_match": {
+      "factual_category_id": "463",
+      "factual_category_label": "Social > Entertainment > Arcades",
+      "is_exact": true
+    }
+  },
+  "10004": {
+    "integrated_label": "Arts and Entertainment > Art Gallery",
+    "single_match": {
+      "factual_category_id": "310",
+      "factual_category_label": "Social > Arts > Art Dealers and Galleries",
+      "is_exact": true
+    }
+  },
+  "10005": {
+    "integrated_label": "Arts and Entertainment > Bingo Center",
+    "single_match": {
+      "factual_category_id": "321",
+      "factual_category_label": "Social > Entertainment > Bingo",
+      "is_exact": true
+    }
+  },
+  "10006": {
+    "integrated_label": "Arts and Entertainment > Bowling Alley",
+    "single_match": {
+      "factual_category_id": "322",
+      "factual_category_label": "Social > Entertainment > Bowling",
+      "is_exact": true
+    }
+  },
+  "10007": {
+    "integrated_label": "Arts and Entertainment > Carnival",
+    "single_match": {
+      "factual_category_id": "323",
+      "factual_category_label": "Social > Entertainment > Carnivals",
+      "is_exact": true
+    }
+  },
+  "10008": {
+    "integrated_label": "Arts and Entertainment > Casino",
+    "single_match": {
+      "factual_category_id": "324",
+      "factual_category_label": "Social > Entertainment > Casinos and Gaming",
+      "is_exact": true
+    }
+  },
+  "10009": {
+    "integrated_label": "Arts and Entertainment > Circus",
+    "single_match": {
+      "factual_category_id": "325",
+      "factual_category_label": "Social > Entertainment > Circuses",
+      "is_exact": true
+    }
+  },
+  "10010": {
+    "integrated_label": "Arts and Entertainment > Comedy Club",
+    "single_match": {
+      "factual_category_id": "481",
+      "factual_category_label": "Social > Entertainment > Comedy Clubs",
+      "is_exact": true
+    }
+  },
+  "10011": {
+    "integrated_label": "Arts and Entertainment > Country Club",
+    "single_match": {
+      "factual_category_id": "369",
+      "factual_category_label": "Social > Country Clubs",
+      "is_exact": true
+    }
+  },
+  "10012": {
+    "integrated_label": "Arts and Entertainment > Country Dance Club",
+    "single_match": {
+      "factual_category_id": "326",
+      "factual_category_label": "Social > Entertainment > Dance Halls and Saloons",
+      "is_exact": false
+    }
+  },
+  "10013": {
+    "integrated_label": "Arts and Entertainment > Dance Hall",
+    "single_match": {
+      "factual_category_id": "326",
+      "factual_category_label": "Social > Entertainment > Dance Halls and Saloons",
+      "is_exact": true
+    }
+  },
+  "10014": {
+    "integrated_label": "Arts and Entertainment > Disc Golf Course",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10015": {
+    "integrated_label": "Arts and Entertainment > Escape Room",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10016": {
+    "integrated_label": "Arts and Entertainment > Exhibit",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": false
+    }
+  },
+  "10017": {
+    "integrated_label": "Arts and Entertainment > Fair",
+    "single_match": {
+      "factual_category_id": "327",
+      "factual_category_label": "Social > Entertainment > Fairgrounds and Rodeos",
+      "is_exact": true
+    }
+  },
+  "10018": {
+    "integrated_label": "Arts and Entertainment > Gaming Cafe",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10019": {
+    "integrated_label": "Arts and Entertainment > Go Kart Track",
+    "single_match": {
+      "factual_category_id": "328",
+      "factual_category_label": "Social > Entertainment > Go Carts",
+      "is_exact": true
+    }
+  },
+  "10020": {
+    "integrated_label": "Arts and Entertainment > Internet Cafe",
+    "single_match": {
+      "factual_category_id": "345",
+      "factual_category_label": "Social > Food and Dining > Internet Cafes",
+      "is_exact": true
+    }
+  },
+  "10021": {
+    "integrated_label": "Arts and Entertainment > Karaoke Box",
+    "single_match": {
+      "factual_category_id": "330",
+      "factual_category_label": "Social > Entertainment > Karaoke",
+      "is_exact": false
+    }
+  },
+  "10022": {
+    "integrated_label": "Arts and Entertainment > Laser Tag Center",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": true
+    }
+  },
+  "10023": {
+    "integrated_label": "Arts and Entertainment > Mini Golf Course",
+    "single_match": {
+      "factual_category_id": "331",
+      "factual_category_label": "Social > Entertainment > Miniature Golf",
+      "is_exact": true
+    }
+  },
+  "10024": {
+    "integrated_label": "Arts and Entertainment > Movie Theater",
+    "single_match": {
+      "factual_category_id": "332",
+      "factual_category_label": "Social > Entertainment > Movie Theatres",
+      "is_exact": true
+    }
+  },
+  "10025": {
+    "integrated_label": "Arts and Entertainment > Movie Theater > Drive-in Theater",
+    "single_match": {
+      "factual_category_id": "332",
+      "factual_category_label": "Social > Entertainment > Movie Theatres",
+      "is_exact": false
+    }
+  },
+  "10026": {
+    "integrated_label": "Arts and Entertainment > Movie Theater > Indie Movie Theater",
+    "single_match": {
+      "factual_category_id": "332",
+      "factual_category_label": "Social > Entertainment > Movie Theatres",
+      "is_exact": false
+    }
+  },
+  "10027": {
+    "integrated_label": "Arts and Entertainment > Museum",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": true
+    }
+  },
+  "10028": {
+    "integrated_label": "Arts and Entertainment > Museum > Art Museum",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": false
+    }
+  },
+  "10029": {
+    "integrated_label": "Arts and Entertainment > Museum > Erotic Museum",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": false
+    }
+  },
+  "10030": {
+    "integrated_label": "Arts and Entertainment > Museum > History Museum",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": false
+    }
+  },
+  "10031": {
+    "integrated_label": "Arts and Entertainment > Museum > Science Museum",
+    "single_match": {
+      "factual_category_id": "311",
+      "factual_category_label": "Social > Arts > Museums",
+      "is_exact": false
+    }
+  },
+  "10032": {
+    "integrated_label": "Arts and Entertainment > Night Club",
+    "single_match": {
+      "factual_category_id": "334",
+      "factual_category_label": "Social > Entertainment > Night Clubs",
+      "is_exact": true
+    }
+  },
+  "10033": {
+    "integrated_label": "Arts and Entertainment > Pachinko Parlor",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10034": {
+    "integrated_label": "Arts and Entertainment > Party Center",
+    "single_match": {
+      "factual_category_id": "335",
+      "factual_category_label": "Social > Entertainment > Party Centers",
+      "is_exact": true
+    }
+  },
+  "10035": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10036": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Amphitheater",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10037": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Concert Hall",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10038": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Indie Theater",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10039": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": true
+    }
+  },
+  "10040": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue > Jazz and Blues Venue",
+    "single_match": {
+      "factual_category_id": "314",
+      "factual_category_label": "Social > Bars > Jazz and Blues Cafes",
+      "is_exact": true
+    }
+  },
+  "10041": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue > Rock Club",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10042": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Opera House",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10043": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Theater",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "10044": {
+    "integrated_label": "Arts and Entertainment > Planetarium",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10045": {
+    "integrated_label": "Arts and Entertainment > Pool Hall",
+    "single_match": {
+      "factual_category_id": "320",
+      "factual_category_label": "Social > Entertainment > Billiard and Pool",
+      "is_exact": true
+    }
+  },
+  "10046": {
+    "integrated_label": "Arts and Entertainment > Psychics and Astrologers",
+    "single_match": {
+      "factual_category_id": "336",
+      "factual_category_label": "Social > Entertainment > Psychics and Astrologers",
+      "is_exact": true
+    }
+  },
+  "10047": {
+    "integrated_label": "Arts and Entertainment > Public Art",
+    "single_match": {
+      "factual_category_id": "309",
+      "factual_category_label": "Social > Arts",
+      "is_exact": false
+    }
+  },
+  "10048": {
+    "integrated_label": "Arts and Entertainment > Roller Rink",
+    "single_match": {
+      "factual_category_id": "402",
+      "factual_category_label": "Sports and Recreation > Skating",
+      "is_exact": false
+    }
+  },
+  "10049": {
+    "integrated_label": "Arts and Entertainment > Salsa Club",
+    "single_match": {
+      "factual_category_id": "379",
+      "factual_category_label": "Sports and Recreation > Dance",
+      "is_exact": false
+    }
+  },
+  "10050": {
+    "integrated_label": "Arts and Entertainment > Samba School",
+    "single_match": {
+      "factual_category_id": "379",
+      "factual_category_label": "Sports and Recreation > Dance",
+      "is_exact": false
+    }
+  },
+  "10051": {
+    "integrated_label": "Arts and Entertainment > Stadium",
+    "single_match": {
+      "factual_category_id": "406",
+      "factual_category_label": "Sports and Recreation > Stadiums and Arenas",
+      "is_exact": true
+    }
+  },
+  "10052": {
+    "integrated_label": "Arts and Entertainment > Strip Club",
+    "single_match": {
+      "factual_category_id": "318",
+      "factual_category_label": "Social > Entertainment > Adult Entertainment",
+      "is_exact": true
+    }
+  },
+  "10053": {
+    "integrated_label": "Arts and Entertainment > Ticket Seller",
+    "single_match": {
+      "factual_category_id": "337",
+      "factual_category_label": "Social > Entertainment > Ticket Sales",
+      "is_exact": true
+    }
+  },
+  "10054": {
+    "integrated_label": "Arts and Entertainment > VR Cafe",
+    "single_match": {
+      "factual_category_id": "317",
+      "factual_category_label": "Social > Entertainment",
+      "is_exact": false
+    }
+  },
+  "10055": {
+    "integrated_label": "Arts and Entertainment > Water Park",
+    "single_match": {
+      "factual_category_id": "319",
+      "factual_category_label": "Social > Entertainment > Amusement Parks",
+      "is_exact": false
+    }
+  },
+  "10056": {
+    "integrated_label": "Arts and Entertainment > Zoo",
+    "single_match": {
+      "factual_category_id": "371",
+      "factual_category_label": "Social > Zoos, Aquariums and Wildlife Sanctuaries",
+      "is_exact": false
+    }
+  },
+  "11000": {
+    "integrated_label": "Business and Professional Services",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": true
+    }
+  },
+  "11001": {
+    "integrated_label": "Business and Professional Services > Advertising Agency",
+    "single_match": {
+      "factual_category_id": "193",
+      "factual_category_label": "Businesses and Services > Advertising and Marketing",
+      "is_exact": true
+    }
+  },
+  "11002": {
+    "integrated_label": "Business and Professional Services > Agriculture and Forestry Service",
+    "single_match": {
+      "factual_category_id": "204",
+      "factual_category_label": "Businesses and Services > Agriculture and Forestry",
+      "is_exact": true
+    }
+  },
+  "11003": {
+    "integrated_label": "Business and Professional Services > Architecture Firm",
+    "single_match": {
+      "factual_category_id": "236",
+      "factual_category_label": "Businesses and Services > Home Improvement > Architects",
+      "is_exact": true
+    }
+  },
+  "11004": {
+    "integrated_label": "Business and Professional Services > Art Restoration Service",
+    "single_match": {
+      "factual_category_id": "205",
+      "factual_category_label": "Businesses and Services > Art Restoration",
+      "is_exact": true
+    }
+  },
+  "11005": {
+    "integrated_label": "Business and Professional Services > Art Studio",
+    "single_match": {
+      "factual_category_id": "309",
+      "factual_category_label": "Social > Arts",
+      "is_exact": false
+    }
+  },
+  "11006": {
+    "integrated_label": "Business and Professional Services > Audiovisual Service",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": true
+    }
+  },
+  "11007": {
+    "integrated_label": "Business and Professional Services > Auditorium",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11008": {
+    "integrated_label": "Business and Professional Services > Automation and Control System",
+    "single_match": {
+      "factual_category_id": "207",
+      "factual_category_label": "Businesses and Services > Automation and Control Systems",
+      "is_exact": true
+    }
+  },
+  "11009": {
+    "integrated_label": "Business and Professional Services > Automotive Service",
+    "single_match": {
+      "factual_category_id": "2",
+      "factual_category_label": "Automotive",
+      "is_exact": false
+    }
+  },
+  "11010": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Automotive Repair Shop",
+    "single_match": {
+      "factual_category_id": "9",
+      "factual_category_label": "Automotive > Maintenance and Repair",
+      "is_exact": true
+    }
+  },
+  "11011": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Car Wash and Detail",
+    "single_match": {
+      "factual_category_id": "7",
+      "factual_category_label": "Automotive > Car Wash and Detail",
+      "is_exact": true
+    }
+  },
+  "11012": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
+    "single_match": {
+      "factual_category_id": "15",
+      "factual_category_label": "Automotive > Motorcycles, Mopeds and Scooters > Repair",
+      "is_exact": true
+    }
+  },
+  "11013": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Oil Change Service",
+    "single_match": {
+      "factual_category_id": "10",
+      "factual_category_label": "Automotive > Maintenance and Repair > Oil and Lube",
+      "is_exact": true
+    }
+  },
+  "11014": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Smog Check Shop",
+    "single_match": {
+      "factual_category_id": "11",
+      "factual_category_label": "Automotive > Maintenance and Repair > Smog Check",
+      "is_exact": true
+    }
+  },
+  "11015": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Tire Repair Shop",
+    "single_match": {
+      "factual_category_id": "12",
+      "factual_category_label": "Automotive > Maintenance and Repair > Tires",
+      "is_exact": true
+    }
+  },
+  "11016": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Towing Service",
+    "single_match": {
+      "factual_category_id": "19",
+      "factual_category_label": "Automotive > Towing",
+      "is_exact": true
+    }
+  },
+  "11017": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Transmissions Shop",
+    "single_match": {
+      "factual_category_id": "13",
+      "factual_category_label": "Automotive > Maintenance and Repair > Transmissions",
+      "is_exact": true
+    }
+  },
+  "11018": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Vehicle Inspection Station",
+    "single_match": {
+      "factual_category_id": "2",
+      "factual_category_label": "Automotive",
+      "is_exact": false
+    }
+  },
+  "11019": {
+    "integrated_label": "Business and Professional Services > Ballroom",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11020": {
+    "integrated_label": "Business and Professional Services > Business and Strategy Consulting Office",
+    "single_match": {
+      "factual_category_id": "178",
+      "factual_category_label": "Businesses and Services > Business and Strategy Consulting",
+      "is_exact": true
+    }
+  },
+  "11021": {
+    "integrated_label": "Business and Professional Services > Business Center",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11022": {
+    "integrated_label": "Business and Professional Services > Campaign Office",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "11023": {
+    "integrated_label": "Business and Professional Services > Career Counselor",
+    "single_match": {
+      "factual_category_id": "446",
+      "factual_category_label": "Businesses and Services > Career Counseling",
+      "is_exact": true
+    }
+  },
+  "11024": {
+    "integrated_label": "Business and Professional Services > Chemicals and Gasses Manufacturer",
+    "single_match": {
+      "factual_category_id": "208",
+      "factual_category_label": "Businesses and Services > Chemicals and Gasses",
+      "is_exact": true
+    }
+  },
+  "11025": {
+    "integrated_label": "Business and Professional Services > Child Care Service",
+    "single_match": {
+      "factual_category_id": "23",
+      "factual_category_label": "Community and Government > Day Care and Preschools",
+      "is_exact": false
+    }
+  },
+  "11026": {
+    "integrated_label": "Business and Professional Services > Child Care Service > Daycare",
+    "single_match": {
+      "factual_category_id": "23",
+      "factual_category_label": "Community and Government > Day Care and Preschools",
+      "is_exact": false
+    }
+  },
+  "11027": {
+    "integrated_label": "Business and Professional Services > Computer Repair Service",
+    "single_match": {
+      "factual_category_id": "209",
+      "factual_category_label": "Businesses and Services > Computers",
+      "is_exact": true
+    }
+  },
+  "11028": {
+    "integrated_label": "Business and Professional Services > Construction",
+    "single_match": {
+      "factual_category_id": "447",
+      "factual_category_label": "Businesses and Services > Construction",
+      "is_exact": true
+    }
+  },
+  "11029": {
+    "integrated_label": "Business and Professional Services > Convention Center",
+    "single_match": {
+      "factual_category_id": "465",
+      "factual_category_label": "Businesses and Services > Events and Event Planning > Convention Centers",
+      "is_exact": true
+    }
+  },
+  "11030": {
+    "integrated_label": "Business and Professional Services > Design Studio",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": false
+    }
+  },
+  "11031": {
+    "integrated_label": "Business and Professional Services > Distribution Center",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11032": {
+    "integrated_label": "Business and Professional Services > Electrical Equipment Supplier",
+    "single_match": {
+      "factual_category_id": "211",
+      "factual_category_label": "Businesses and Services > Electrical Equipment",
+      "is_exact": true
+    }
+  },
+  "11033": {
+    "integrated_label": "Business and Professional Services > Employment Agency",
+    "single_match": {
+      "factual_category_id": "212",
+      "factual_category_label": "Businesses and Services > Employment Agencies",
+      "is_exact": true
+    }
+  },
+  "11034": {
+    "integrated_label": "Business and Professional Services > Engineer",
+    "single_match": {
+      "factual_category_id": "213",
+      "factual_category_label": "Businesses and Services > Engineering",
+      "is_exact": true
+    }
+  },
+  "11035": {
+    "integrated_label": "Business and Professional Services > Entertainment Agency",
+    "single_match": {
+      "factual_category_id": "214",
+      "factual_category_label": "Businesses and Services > Entertainment",
+      "is_exact": false
+    }
+  },
+  "11036": {
+    "integrated_label": "Business and Professional Services > Entertainment Service",
+    "single_match": {
+      "factual_category_id": "214",
+      "factual_category_label": "Businesses and Services > Entertainment",
+      "is_exact": false
+    }
+  },
+  "11037": {
+    "integrated_label": "Business and Professional Services > Equipment Rental Service",
+    "single_match": {
+      "factual_category_id": "216",
+      "factual_category_label": "Businesses and Services > Equipment Rental",
+      "is_exact": true
+    }
+  },
+  "11038": {
+    "integrated_label": "Business and Professional Services > Event Service",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": true
+    }
+  },
+  "11039": {
+    "integrated_label": "Business and Professional Services > Event Space",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "11040": {
+    "integrated_label": "Business and Professional Services > Factory",
+    "single_match": {
+      "factual_category_id": "275",
+      "factual_category_label": "Businesses and Services > Manufacturing",
+      "is_exact": false
+    }
+  },
+  "11041": {
+    "integrated_label": "Business and Professional Services > Film Studio",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": false
+    }
+  },
+  "11042": {
+    "integrated_label": "Business and Professional Services > Financial Service",
+    "single_match": {
+      "factual_category_id": "219",
+      "factual_category_label": "Businesses and Services > Financial",
+      "is_exact": true
+    }
+  },
+  "11043": {
+    "integrated_label": "Business and Professional Services > Financial Service > Accounting and Bookkeeping Service",
+    "single_match": {
+      "factual_category_id": "220",
+      "factual_category_label": "Businesses and Services > Financial > Accounting and Bookkeeping",
+      "is_exact": true
+    }
+  },
+  "11044": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > ATM",
+    "single_match": {
+      "factual_category_id": "218",
+      "factual_category_label": "Businesses and Services > Financial > Banking and Finance > ATMs",
+      "is_exact": true
+    }
+  },
+  "11045": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > Bank",
+    "single_match": {
+      "factual_category_id": "473",
+      "factual_category_label": "Businesses and Services > Financial > Banking and Finance > Banks and Credit Unions",
+      "is_exact": false
+    }
+  },
+  "11046": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance",
+    "single_match": {
+      "factual_category_id": "221",
+      "factual_category_label": "Businesses and Services > Financial > Banking and Finance",
+      "is_exact": true
+    }
+  },
+  "11047": {
+    "integrated_label": "Business and Professional Services > Financial Service > Business Broker",
+    "single_match": {
+      "factual_category_id": "222",
+      "factual_category_label": "Businesses and Services > Financial > Business Brokers and Franchises",
+      "is_exact": true
+    }
+  },
+  "11048": {
+    "integrated_label": "Business and Professional Services > Financial Service > Check Cashing Service",
+    "single_match": {
+      "factual_category_id": "223",
+      "factual_category_label": "Businesses and Services > Financial > Check Cashing",
+      "is_exact": true
+    }
+  },
+  "11049": {
+    "integrated_label": "Business and Professional Services > Financial Service > Collections Service",
+    "single_match": {
+      "factual_category_id": "224",
+      "factual_category_label": "Businesses and Services > Financial > Collections",
+      "is_exact": true
+    }
+  },
+  "11050": {
+    "integrated_label": "Business and Professional Services > Financial Service > Credit Counseling and Bankruptcy Service",
+    "single_match": {
+      "factual_category_id": "270",
+      "factual_category_label": "Businesses and Services > Legal > Credit Counseling and Bankruptcy Services",
+      "is_exact": true
+    }
+  },
+  "11051": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > Credit Union",
+    "single_match": {
+      "factual_category_id": "473",
+      "factual_category_label": "Businesses and Services > Financial > Banking and Finance > Banks and Credit Unions",
+      "is_exact": false
+    }
+  },
+  "11052": {
+    "integrated_label": "Business and Professional Services > Financial Service > Currency Exchange",
+    "single_match": {
+      "factual_category_id": "219",
+      "factual_category_label": "Businesses and Services > Financial",
+      "is_exact": false
+    }
+  },
+  "11053": {
+    "integrated_label": "Business and Professional Services > Financial Service > Financial Planner",
+    "single_match": {
+      "factual_category_id": "225",
+      "factual_category_label": "Businesses and Services > Financial > Financial Planning and Investments",
+      "is_exact": true
+    }
+  },
+  "11054": {
+    "integrated_label": "Business and Professional Services > Financial Service > Loans Agency",
+    "single_match": {
+      "factual_category_id": "227",
+      "factual_category_label": "Businesses and Services > Financial > Loans and Mortgages",
+      "is_exact": true
+    }
+  },
+  "11055": {
+    "integrated_label": "Business and Professional Services > Financial Service > Stock Broker",
+    "single_match": {
+      "factual_category_id": "228",
+      "factual_category_label": "Businesses and Services > Financial > Stock Brokers",
+      "is_exact": true
+    }
+  },
+  "11056": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service",
+    "single_match": {
+      "factual_category_id": "230",
+      "factual_category_label": "Businesses and Services > Food and Beverage",
+      "is_exact": true
+    }
+  },
+  "11057": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service > Caterer",
+    "single_match": {
+      "factual_category_id": "231",
+      "factual_category_label": "Businesses and Services > Food and Beverage > Catering",
+      "is_exact": true
+    }
+  },
+  "11058": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service > Food Distribution Center",
+    "single_match": {
+      "factual_category_id": "232",
+      "factual_category_label": "Businesses and Services > Food and Beverage > Distribution",
+      "is_exact": true
+    }
+  },
+  "11059": {
+    "integrated_label": "Business and Professional Services > Funeral Home",
+    "single_match": {
+      "factual_category_id": "233",
+      "factual_category_label": "Businesses and Services > Funeral Services",
+      "is_exact": true
+    }
+  },
+  "11060": {
+    "integrated_label": "Business and Professional Services > Geological Service",
+    "single_match": {
+      "factual_category_id": "234",
+      "factual_category_label": "Businesses and Services > Geological",
+      "is_exact": true
+    }
+  },
+  "11061": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service",
+    "single_match": {
+      "factual_category_id": "277",
+      "factual_category_label": "Businesses and Services > Personal Care",
+      "is_exact": true
+    }
+  },
+  "11062": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Barbershop",
+    "single_match": {
+      "factual_category_id": "280",
+      "factual_category_label": "Businesses and Services > Personal Care > Beauty Salons and Barbers",
+      "is_exact": false
+    }
+  },
+  "11063": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Bath House",
+    "single_match": {
+      "factual_category_id": "277",
+      "factual_category_label": "Businesses and Services > Personal Care",
+      "is_exact": false
+    }
+  },
+  "11064": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Hair Salon",
+    "single_match": {
+      "factual_category_id": "280",
+      "factual_category_label": "Businesses and Services > Personal Care > Beauty Salons and Barbers",
+      "is_exact": false
+    }
+  },
+  "11065": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Body Piercing Shop",
+    "single_match": {
+      "factual_category_id": "283",
+      "factual_category_label": "Businesses and Services > Personal Care > Piercing",
+      "is_exact": true
+    }
+  },
+  "11066": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Dry Cleaner",
+    "single_match": {
+      "factual_category_id": "278",
+      "factual_category_label": "Businesses and Services > Personal Care > Dry Cleaning, Ironing and Laundry",
+      "is_exact": false
+    }
+  },
+  "11067": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Hair Removal Service",
+    "single_match": {
+      "factual_category_id": "279",
+      "factual_category_label": "Businesses and Services > Personal Care > Hair Removal",
+      "is_exact": true
+    }
+  },
+  "11068": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Laundromat",
+    "single_match": {
+      "factual_category_id": "278",
+      "factual_category_label": "Businesses and Services > Personal Care > Dry Cleaning, Ironing and Laundry",
+      "is_exact": false
+    }
+  },
+  "11069": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Laundry Service",
+    "single_match": {
+      "factual_category_id": "278",
+      "factual_category_label": "Businesses and Services > Personal Care > Dry Cleaning, Ironing and Laundry",
+      "is_exact": false
+    }
+  },
+  "11070": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Massage Clinic",
+    "single_match": {
+      "factual_category_id": "282",
+      "factual_category_label": "Businesses and Services > Personal Care > Massage Clinics and Therapists",
+      "is_exact": true
+    }
+  },
+  "11071": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Nail Salon",
+    "single_match": {
+      "factual_category_id": "281",
+      "factual_category_label": "Businesses and Services > Personal Care > Manicures and Pedicures",
+      "is_exact": true
+    }
+  },
+  "11072": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Skin Care Clinic",
+    "single_match": {
+      "factual_category_id": "284",
+      "factual_category_label": "Businesses and Services > Personal Care > Skin Care",
+      "is_exact": true
+    }
+  },
+  "11073": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Spa",
+    "single_match": {
+      "factual_category_id": "285",
+      "factual_category_label": "Businesses and Services > Personal Care > Spas",
+      "is_exact": true
+    }
+  },
+  "11074": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Tanning Salon",
+    "single_match": {
+      "factual_category_id": "286",
+      "factual_category_label": "Businesses and Services > Personal Care > Tanning Salons",
+      "is_exact": true
+    }
+  },
+  "11075": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Tattoo Parlor",
+    "single_match": {
+      "factual_category_id": "287",
+      "factual_category_label": "Businesses and Services > Personal Care > Tattooing",
+      "is_exact": true
+    }
+  },
+  "11076": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service",
+    "single_match": {
+      "factual_category_id": "235",
+      "factual_category_label": "Businesses and Services > Home Improvement",
+      "is_exact": true
+    }
+  },
+  "11077": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Bathroom Contractor",
+    "single_match": {
+      "factual_category_id": "240",
+      "factual_category_label": "Businesses and Services > Home Improvement > Contractors > Bathrooms",
+      "is_exact": true
+    }
+  },
+  "11078": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Carpenter",
+    "single_match": {
+      "factual_category_id": "237",
+      "factual_category_label": "Businesses and Services > Home Improvement > Carpenters",
+      "is_exact": true
+    }
+  },
+  "11079": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Carpet and Flooring Contractor",
+    "single_match": {
+      "factual_category_id": "238",
+      "factual_category_label": "Businesses and Services > Home Improvement > Carpet and Flooring",
+      "is_exact": true
+    }
+  },
+  "11080": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Chimney Sweep",
+    "single_match": {
+      "factual_category_id": "245",
+      "factual_category_label": "Businesses and Services > Home Improvement > Fences, Fireplaces and Garage Doors",
+      "is_exact": false
+    }
+  },
+  "11081": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Deck and Patio Contractor",
+    "single_match": {
+      "factual_category_id": "239",
+      "factual_category_label": "Businesses and Services > Home Improvement > Contractors",
+      "is_exact": false
+    }
+  },
+  "11082": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Doors and Windows Contractor",
+    "single_match": {
+      "factual_category_id": "241",
+      "factual_category_label": "Businesses and Services > Home Improvement > Contractors > Deck and Patio",
+      "is_exact": true
+    }
+  },
+  "11083": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Electrician",
+    "single_match": {
+      "factual_category_id": "243",
+      "factual_category_label": "Businesses and Services > Home Improvement > Doors and Windows",
+      "is_exact": true
+    }
+  },
+  "11084": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Fence Contractor",
+    "single_match": {
+      "factual_category_id": "244",
+      "factual_category_label": "Businesses and Services > Home Improvement > Electricians",
+      "is_exact": true
+    }
+  },
+  "11085": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Garage Door Supplier",
+    "single_match": {
+      "factual_category_id": "245",
+      "factual_category_label": "Businesses and Services > Home Improvement > Fences, Fireplaces and Garage Doors",
+      "is_exact": false
+    }
+  },
+  "11086": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > General Contractor",
+    "single_match": {
+      "factual_category_id": "239",
+      "factual_category_label": "Businesses and Services > Home Improvement > Contractors",
+      "is_exact": true
+    }
+  },
+  "11087": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Heating, Ventilating and Air Conditioning Contractor",
+    "single_match": {
+      "factual_category_id": "247",
+      "factual_category_label": "Businesses and Services > Home Improvement > Heating, Ventilating and Air Conditioning",
+      "is_exact": true
+    }
+  },
+  "11088": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Home Inspection",
+    "single_match": {
+      "factual_category_id": "249",
+      "factual_category_label": "Businesses and Services > Home Improvement > Home Inspection Services",
+      "is_exact": true
+    }
+  },
+  "11089": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Home Service",
+    "single_match": {
+      "factual_category_id": "246",
+      "factual_category_label": "Businesses and Services > Home Improvement > Hardware and Services",
+      "is_exact": true
+    }
+  },
+  "11090": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Interior Designer",
+    "single_match": {
+      "factual_category_id": "251",
+      "factual_category_label": "Businesses and Services > Home Improvement > Interior Design",
+      "is_exact": true
+    }
+  },
+  "11091": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Kitchen Remodeler",
+    "single_match": {
+      "factual_category_id": "252",
+      "factual_category_label": "Businesses and Services > Home Improvement > Kitchens",
+      "is_exact": true
+    }
+  },
+  "11092": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Landscaper and Gardener",
+    "single_match": {
+      "factual_category_id": "253",
+      "factual_category_label": "Businesses and Services > Home Improvement > Landscaping and Gardeners",
+      "is_exact": true
+    }
+  },
+  "11093": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Mover",
+    "single_match": {
+      "factual_category_id": "256",
+      "factual_category_label": "Businesses and Services > Home Improvement > Movers",
+      "is_exact": true
+    }
+  },
+  "11094": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Painter",
+    "single_match": {
+      "factual_category_id": "257",
+      "factual_category_label": "Businesses and Services > Home Improvement > Painting",
+      "is_exact": true
+    }
+  },
+  "11095": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Pest Control Service",
+    "single_match": {
+      "factual_category_id": "258",
+      "factual_category_label": "Businesses and Services > Home Improvement > Pest Control",
+      "is_exact": true
+    }
+  },
+  "11096": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Plumber",
+    "single_match": {
+      "factual_category_id": "259",
+      "factual_category_label": "Businesses and Services > Home Improvement > Plumbing",
+      "is_exact": true
+    }
+  },
+  "11097": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Professional Cleaning Service",
+    "single_match": {
+      "factual_category_id": "289",
+      "factual_category_label": "Businesses and Services > Professional Cleaning",
+      "is_exact": true
+    }
+  },
+  "11098": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Roofer",
+    "single_match": {
+      "factual_category_id": "261",
+      "factual_category_label": "Businesses and Services > Home Improvement > Roofers",
+      "is_exact": true
+    }
+  },
+  "11099": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Sewer Contractor",
+    "single_match": {
+      "factual_category_id": "242",
+      "factual_category_label": "Businesses and Services > Home Improvement > Contractors > Sewer",
+      "is_exact": true
+    }
+  },
+  "11100": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Swimming Pool Maintenance and Service",
+    "single_match": {
+      "factual_category_id": "263",
+      "factual_category_label": "Businesses and Services > Home Improvement > Swimming Pool Maintenance and Services",
+      "is_exact": true
+    }
+  },
+  "11101": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Tree Service",
+    "single_match": {
+      "factual_category_id": "264",
+      "factual_category_label": "Businesses and Services > Home Improvement > Tree Service",
+      "is_exact": true
+    }
+  },
+  "11102": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Upholstery Service",
+    "single_match": {
+      "factual_category_id": "265",
+      "factual_category_label": "Businesses and Services > Home Improvement > Upholstery",
+      "is_exact": true
+    }
+  },
+  "11103": {
+    "integrated_label": "Business and Professional Services > Human Resources Agency",
+    "single_match": {
+      "factual_category_id": "266",
+      "factual_category_label": "Businesses and Services > Human Resources",
+      "is_exact": true
+    }
+  },
+  "11104": {
+    "integrated_label": "Business and Professional Services > Import and Export Service",
+    "single_match": {
+      "factual_category_id": "267",
+      "factual_category_label": "Businesses and Services > Import and Export",
+      "is_exact": true
+    }
+  },
+  "11105": {
+    "integrated_label": "Business and Professional Services > Industrial Equipment Supplier",
+    "single_match": {
+      "factual_category_id": "179",
+      "factual_category_label": "Businesses and Services > Industrial Machinery and Vehicles",
+      "is_exact": true
+    }
+  },
+  "11106": {
+    "integrated_label": "Business and Professional Services > Industrial Estate",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11107": {
+    "integrated_label": "Business and Professional Services > Insurance Agency",
+    "single_match": {
+      "factual_category_id": "272",
+      "factual_category_label": "Businesses and Services > Insurance",
+      "is_exact": true
+    }
+  },
+  "11108": {
+    "integrated_label": "Business and Professional Services > Technology Business > IT Service",
+    "single_match": {
+      "factual_category_id": "460",
+      "factual_category_label": "Businesses and Services > Technology",
+      "is_exact": false
+    }
+  },
+  "11109": {
+    "integrated_label": "Business and Professional Services > Laboratory",
+    "single_match": {
+      "factual_category_id": "187",
+      "factual_category_label": "Businesses and Services > Scientific",
+      "is_exact": false
+    }
+  },
+  "11110": {
+    "integrated_label": "Business and Professional Services > Leather Supplier",
+    "single_match": {
+      "factual_category_id": "268",
+      "factual_category_label": "Businesses and Services > Leather",
+      "is_exact": true
+    }
+  },
+  "11111": {
+    "integrated_label": "Business and Professional Services > Legal Service",
+    "single_match": {
+      "factual_category_id": "269",
+      "factual_category_label": "Businesses and Services > Legal",
+      "is_exact": true
+    }
+  },
+  "11112": {
+    "integrated_label": "Business and Professional Services > Legal Service > Attorney / Law Office",
+    "single_match": {
+      "factual_category_id": "474",
+      "factual_category_label": "Businesses and Services > Legal > Attorneys and Law Offices",
+      "is_exact": true
+    }
+  },
+  "11113": {
+    "integrated_label": "Business and Professional Services > Legal Service > Immigration Attorney",
+    "single_match": {
+      "factual_category_id": "271",
+      "factual_category_label": "Businesses and Services > Legal > Immigration",
+      "is_exact": true
+    }
+  },
+  "11114": {
+    "integrated_label": "Business and Professional Services > Legal Service > Notary",
+    "single_match": {
+      "factual_category_id": "448",
+      "factual_category_label": "Businesses and Services > Legal > Notary",
+      "is_exact": true
+    }
+  },
+  "11115": {
+    "integrated_label": "Business and Professional Services > Locksmith",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11116": {
+    "integrated_label": "Business and Professional Services > Logging Service",
+    "single_match": {
+      "factual_category_id": "180",
+      "factual_category_label": "Businesses and Services > Logging and Sawmills",
+      "is_exact": true
+    }
+  },
+  "11117": {
+    "integrated_label": "Business and Professional Services > Lottery Retailer",
+    "single_match": {
+      "factual_category_id": "324",
+      "factual_category_label": "Social > Entertainment > Casinos and Gaming",
+      "is_exact": false
+    }
+  },
+  "11118": {
+    "integrated_label": "Business and Professional Services > Machine Shop",
+    "single_match": {
+      "factual_category_id": "273",
+      "factual_category_label": "Businesses and Services > Machine Shops",
+      "is_exact": true
+    }
+  },
+  "11119": {
+    "integrated_label": "Business and Professional Services > Management Consultant",
+    "single_match": {
+      "factual_category_id": "274",
+      "factual_category_label": "Businesses and Services > Management",
+      "is_exact": true
+    }
+  },
+  "11120": {
+    "integrated_label": "Business and Professional Services > Manufacturer",
+    "single_match": {
+      "factual_category_id": "275",
+      "factual_category_label": "Businesses and Services > Manufacturing",
+      "is_exact": true
+    }
+  },
+  "11121": {
+    "integrated_label": "Business and Professional Services > Media Agency",
+    "single_match": {
+      "factual_category_id": "215",
+      "factual_category_label": "Businesses and Services > Entertainment > Media",
+      "is_exact": true
+    }
+  },
+  "11122": {
+    "integrated_label": "Business and Professional Services > Metals Supplier",
+    "single_match": {
+      "factual_category_id": "181",
+      "factual_category_label": "Businesses and Services > Metals",
+      "is_exact": true
+    }
+  },
+  "11123": {
+    "integrated_label": "Business and Professional Services > Mobile Company",
+    "single_match": {
+      "factual_category_id": "455",
+      "factual_category_label": "Businesses and Services > Technology > Mobile",
+      "is_exact": true
+    }
+  },
+  "11124": {
+    "integrated_label": "Business and Professional Services > Office",
+    "single_match": {
+      "factual_category_id": "210",
+      "factual_category_label": "Businesses and Services > Corporate HQ",
+      "is_exact": true
+    }
+  },
+  "11125": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Cafeteria",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "11126": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Coffee Shop",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": false
+    }
+  },
+  "11127": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Housing Agency",
+    "single_match": {
+      "factual_category_id": "300",
+      "factual_category_label": "Businesses and Services > Real Estate > Corporate Housing",
+      "is_exact": true
+    }
+  },
+  "11128": {
+    "integrated_label": "Business and Professional Services > Office > Coworking Space",
+    "single_match": {
+      "factual_category_id": "299",
+      "factual_category_label": "Businesses and Services > Real Estate > Commercial Real Estate",
+      "is_exact": false
+    }
+  },
+  "11129": {
+    "integrated_label": "Business and Professional Services > Office > Meeting Room",
+    "single_match": {
+      "factual_category_id": "210",
+      "factual_category_label": "Businesses and Services > Corporate HQ",
+      "is_exact": false
+    }
+  },
+  "11130": {
+    "integrated_label": "Business and Professional Services > Office > Office Building",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "11131": {
+    "integrated_label": "Business and Professional Services > Outdoor Event Space",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "11132": {
+    "integrated_label": "Business and Professional Services > Paper Supplier",
+    "single_match": {
+      "factual_category_id": "276",
+      "factual_category_label": "Businesses and Services > Paper",
+      "is_exact": true
+    }
+  },
+  "11133": {
+    "integrated_label": "Business and Professional Services > Pet Service",
+    "single_match": {
+      "factual_category_id": "167",
+      "factual_category_label": "Retail > Pets",
+      "is_exact": false
+    }
+  },
+  "11134": {
+    "integrated_label": "Business and Professional Services > Pet Service > Pet Grooming Service",
+    "single_match": {
+      "factual_category_id": "470",
+      "factual_category_label": "Retail > Pets > Grooming",
+      "is_exact": true
+    }
+  },
+  "11135": {
+    "integrated_label": "Business and Professional Services > Pet Service > Pet Sitting and Boarding Service",
+    "single_match": {
+      "factual_category_id": "469",
+      "factual_category_label": "Retail > Pets > Pet Sitting and Boarding",
+      "is_exact": true
+    }
+  },
+  "11136": {
+    "integrated_label": "Business and Professional Services > Petroleum Supplier",
+    "single_match": {
+      "factual_category_id": "183",
+      "factual_category_label": "Businesses and Services > Petroleum",
+      "is_exact": true
+    }
+  },
+  "11137": {
+    "integrated_label": "Business and Professional Services > Photography Service",
+    "single_match": {
+      "factual_category_id": "449",
+      "factual_category_label": "Businesses and Services > Photography",
+      "is_exact": false
+    }
+  },
+  "11138": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photographer",
+    "single_match": {
+      "factual_category_id": "449",
+      "factual_category_label": "Businesses and Services > Photography",
+      "is_exact": true
+    }
+  },
+  "11139": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photography Lab",
+    "single_match": {
+      "factual_category_id": "449",
+      "factual_category_label": "Businesses and Services > Photography",
+      "is_exact": false
+    }
+  },
+  "11140": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photography Studio",
+    "single_match": {
+      "factual_category_id": "449",
+      "factual_category_label": "Businesses and Services > Photography",
+      "is_exact": false
+    }
+  },
+  "11141": {
+    "integrated_label": "Business and Professional Services > Plastics Supplier",
+    "single_match": {
+      "factual_category_id": "184",
+      "factual_category_label": "Businesses and Services > Plastics",
+      "is_exact": true
+    }
+  },
+  "11142": {
+    "integrated_label": "Business and Professional Services > Power Plant",
+    "single_match": {
+      "factual_category_id": "213",
+      "factual_category_label": "Businesses and Services > Engineering",
+      "is_exact": false
+    }
+  },
+  "11143": {
+    "integrated_label": "Business and Professional Services > Publisher",
+    "single_match": {
+      "factual_category_id": "290",
+      "factual_category_label": "Businesses and Services > Publishing",
+      "is_exact": true
+    }
+  },
+  "11144": {
+    "integrated_label": "Business and Professional Services > Radio Station",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": false
+    }
+  },
+  "11145": {
+    "integrated_label": "Business and Professional Services > Real Estate Service",
+    "single_match": {
+      "factual_category_id": "291",
+      "factual_category_label": "Businesses and Services > Real Estate",
+      "is_exact": true
+    }
+  },
+  "11146": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Building and Land Surveyor",
+    "single_match": {
+      "factual_category_id": "298",
+      "factual_category_label": "Businesses and Services > Real Estate > Building and Land Surveyors",
+      "is_exact": true
+    }
+  },
+  "11147": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Commercial Real Estate Developer",
+    "single_match": {
+      "factual_category_id": "299",
+      "factual_category_label": "Businesses and Services > Real Estate > Commercial Real Estate",
+      "is_exact": true
+    }
+  },
+  "11148": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Property Management Office",
+    "single_match": {
+      "factual_category_id": "292",
+      "factual_category_label": "Businesses and Services > Real Estate > Property Management",
+      "is_exact": true
+    }
+  },
+  "11149": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Agency",
+    "single_match": {
+      "factual_category_id": "293",
+      "factual_category_label": "Businesses and Services > Real Estate > Real Estate Agents",
+      "is_exact": true
+    }
+  },
+  "11150": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Appraiser",
+    "single_match": {
+      "factual_category_id": "294",
+      "factual_category_label": "Businesses and Services > Real Estate > Real Estate Appraiser",
+      "is_exact": true
+    }
+  },
+  "11151": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Development and Title Company",
+    "single_match": {
+      "factual_category_id": "295",
+      "factual_category_label": "Businesses and Services > Real Estate > Real Estate Development and Title Companies",
+      "is_exact": true
+    }
+  },
+  "11152": {
+    "integrated_label": "Business and Professional Services > Recording Studio",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": false
+    }
+  },
+  "11153": {
+    "integrated_label": "Business and Professional Services > Recycling Facility",
+    "single_match": {
+      "factual_category_id": "191",
+      "factual_category_label": "Businesses and Services > Water and Waste Management",
+      "is_exact": false
+    }
+  },
+  "11154": {
+    "integrated_label": "Business and Professional Services > Refrigeration and Ice Supplier",
+    "single_match": {
+      "factual_category_id": "185",
+      "factual_category_label": "Businesses and Services > Refrigeration and Ice",
+      "is_exact": true
+    }
+  },
+  "11155": {
+    "integrated_label": "Business and Professional Services > Renewable Energy Service",
+    "single_match": {
+      "factual_category_id": "301",
+      "factual_category_label": "Businesses and Services > Renewable Energy",
+      "is_exact": true
+    }
+  },
+  "11156": {
+    "integrated_label": "Business and Professional Services > Rental Service",
+    "single_match": {
+      "factual_category_id": "177",
+      "factual_category_label": "Businesses and Services",
+      "is_exact": false
+    }
+  },
+  "11157": {
+    "integrated_label": "Business and Professional Services > Repair Service",
+    "single_match": {
+      "factual_category_id": "302",
+      "factual_category_label": "Businesses and Services > Repair Services",
+      "is_exact": true
+    }
+  },
+  "11158": {
+    "integrated_label": "Business and Professional Services > Research Station",
+    "single_match": {
+      "factual_category_id": "187",
+      "factual_category_label": "Businesses and Services > Scientific",
+      "is_exact": false
+    }
+  },
+  "11159": {
+    "integrated_label": "Business and Professional Services > Rubber Supplier",
+    "single_match": {
+      "factual_category_id": "186",
+      "factual_category_label": "Businesses and Services > Rubber",
+      "is_exact": true
+    }
+  },
+  "11160": {
+    "integrated_label": "Business and Professional Services > Salvage Yard",
+    "single_match": {
+      "factual_category_id": "18",
+      "factual_category_label": "Automotive > Salvage Yards",
+      "is_exact": true
+    }
+  },
+  "11161": {
+    "integrated_label": "Business and Professional Services > Scientific Equipment Supplier",
+    "single_match": {
+      "factual_category_id": "187",
+      "factual_category_label": "Businesses and Services > Scientific",
+      "is_exact": true
+    }
+  },
+  "11162": {
+    "integrated_label": "Business and Professional Services > Security and Safety",
+    "single_match": {
+      "factual_category_id": "188",
+      "factual_category_label": "Businesses and Services > Security and Safety",
+      "is_exact": true
+    }
+  },
+  "11163": {
+    "integrated_label": "Business and Professional Services > Shipping, Freight, and Material Transportation Service",
+    "single_match": {
+      "factual_category_id": "303",
+      "factual_category_label": "Businesses and Services > Shipping, Freight, and Material Transportation",
+      "is_exact": true
+    }
+  },
+  "11164": {
+    "integrated_label": "Business and Professional Services > Shoe Repair Service",
+    "single_match": {
+      "factual_category_id": "302",
+      "factual_category_label": "Businesses and Services > Repair Services",
+      "is_exact": false
+    }
+  },
+  "11165": {
+    "integrated_label": "Business and Professional Services > Storage Facility",
+    "single_match": {
+      "factual_category_id": "262",
+      "factual_category_label": "Businesses and Services > Storage",
+      "is_exact": true
+    }
+  },
+  "11166": {
+    "integrated_label": "Business and Professional Services > Tailor",
+    "single_match": {
+      "factual_category_id": "304",
+      "factual_category_label": "Businesses and Services > Tailors",
+      "is_exact": true
+    }
+  },
+  "11167": {
+    "integrated_label": "Business and Professional Services > Technology Business",
+    "single_match": {
+      "factual_category_id": "460",
+      "factual_category_label": "Businesses and Services > Technology",
+      "is_exact": true
+    }
+  },
+  "11168": {
+    "integrated_label": "Business and Professional Services > Technology Business > Software Company",
+    "single_match": {
+      "factual_category_id": "454",
+      "factual_category_label": "Businesses and Services > Technology > Infrastructure",
+      "is_exact": true
+    }
+  },
+  "11169": {
+    "integrated_label": "Business and Professional Services > Technology Business > Website Designer",
+    "single_match": {
+      "factual_category_id": "306",
+      "factual_category_label": "Businesses and Services > Technology > Web Design and Development",
+      "is_exact": true
+    }
+  },
+  "11170": {
+    "integrated_label": "Business and Professional Services > Telecommunication Service",
+    "single_match": {
+      "factual_category_id": "189",
+      "factual_category_label": "Businesses and Services > Telecommunication Services",
+      "is_exact": true
+    }
+  },
+  "11171": {
+    "integrated_label": "Business and Professional Services > Translation Service",
+    "single_match": {
+      "factual_category_id": "450",
+      "factual_category_label": "Businesses and Services > Translation Services",
+      "is_exact": true
+    }
+  },
+  "11172": {
+    "integrated_label": "Business and Professional Services > Tutoring Service",
+    "single_match": {
+      "factual_category_id": "35",
+      "factual_category_label": "Community and Government > Education > Tutoring and Educational Services",
+      "is_exact": true
+    }
+  },
+  "11173": {
+    "integrated_label": "Business and Professional Services > TV Station",
+    "single_match": {
+      "factual_category_id": "206",
+      "factual_category_label": "Businesses and Services > Audiovisual",
+      "is_exact": false
+    }
+  },
+  "11174": {
+    "integrated_label": "Business and Professional Services > Warehouse",
+    "single_match": {
+      "factual_category_id": "175",
+      "factual_category_label": "Retail > Warehouses and Wholesale Stores",
+      "is_exact": false
+    }
+  },
+  "11175": {
+    "integrated_label": "Business and Professional Services > Waste Management Service",
+    "single_match": {
+      "factual_category_id": "191",
+      "factual_category_label": "Businesses and Services > Water and Waste Management",
+      "is_exact": true
+    }
+  },
+  "11176": {
+    "integrated_label": "Business and Professional Services > Water Treatment Service",
+    "single_match": {
+      "factual_category_id": "191",
+      "factual_category_label": "Businesses and Services > Water and Waste Management",
+      "is_exact": true
+    }
+  },
+  "11177": {
+    "integrated_label": "Business and Professional Services > Wedding Hall",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "11178": {
+    "integrated_label": "Business and Professional Services > Welding Service",
+    "single_match": {
+      "factual_category_id": "192",
+      "factual_category_label": "Businesses and Services > Welding",
+      "is_exact": true
+    }
+  },
+  "11179": {
+    "integrated_label": "Business and Professional Services > Wholesaler",
+    "single_match": {
+      "factual_category_id": "307",
+      "factual_category_label": "Businesses and Services > Wholesale",
+      "is_exact": true
+    }
+  },
+  "12000": {
+    "integrated_label": "Community and Government",
+    "single_match": {
+      "factual_category_id": "20",
+      "factual_category_label": "Community and Government",
+      "is_exact": true
+    }
+  },
+  "12001": {
+    "integrated_label": "Community and Government > Addiction Treatment Center",
+    "single_match": {
+      "factual_category_id": "25",
+      "factual_category_label": "Community and Government > Drug and Alcohol Services",
+      "is_exact": true
+    }
+  },
+  "12002": {
+    "integrated_label": "Community and Government > Animal Shelter",
+    "single_match": {
+      "factual_category_id": "21",
+      "factual_category_label": "Community and Government > Animal Shelters and Humane Societies",
+      "is_exact": true
+    }
+  },
+  "12003": {
+    "integrated_label": "Community and Government > Cemetery",
+    "single_match": {
+      "factual_category_id": "22",
+      "factual_category_label": "Community and Government > Cemeteries",
+      "is_exact": true
+    }
+  },
+  "12004": {
+    "integrated_label": "Community and Government > Community Center",
+    "single_match": {
+      "factual_category_id": "52",
+      "factual_category_label": "Community and Government > Public and Social Services",
+      "is_exact": false
+    }
+  },
+  "12005": {
+    "integrated_label": "Community and Government > Cultural Center",
+    "single_match": {
+      "factual_category_id": "20",
+      "factual_category_label": "Community and Government",
+      "is_exact": false
+    }
+  },
+  "12006": {
+    "integrated_label": "Community and Government > Disabled Persons Service",
+    "single_match": {
+      "factual_category_id": "24",
+      "factual_category_label": "Community and Government > Disabled Persons Services",
+      "is_exact": true
+    }
+  },
+  "12007": {
+    "integrated_label": "Community and Government > Domestic Abuse Treatment Center",
+    "single_match": {
+      "factual_category_id": "52",
+      "factual_category_label": "Community and Government > Public and Social Services",
+      "is_exact": false
+    }
+  },
+  "12008": {
+    "integrated_label": "Community and Government > Dump",
+    "single_match": {
+      "factual_category_id": "20",
+      "factual_category_label": "Community and Government",
+      "is_exact": false
+    }
+  },
+  "12009": {
+    "integrated_label": "Community and Government > Education",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": true
+    }
+  },
+  "12010": {
+    "integrated_label": "Community and Government > Education > Adult Education",
+    "single_match": {
+      "factual_category_id": "27",
+      "factual_category_label": "Community and Government > Education > Adult Education",
+      "is_exact": true
+    }
+  },
+  "12011": {
+    "integrated_label": "Community and Government > Education > Art School",
+    "single_match": {
+      "factual_category_id": "28",
+      "factual_category_label": "Community and Government > Education > Art Lessons and Schools",
+      "is_exact": true
+    }
+  },
+  "12012": {
+    "integrated_label": "Community and Government > Education > Circus School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12013": {
+    "integrated_label": "Community and Government > Education > College and University",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": true
+    }
+  },
+  "12014": {
+    "integrated_label": "Community and Government > Education > College and University > College Academic Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12015": {
+    "integrated_label": "Community and Government > Education > College and University > College Administrative Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12016": {
+    "integrated_label": "Community and Government > Education > College and University > College Arts Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12017": {
+    "integrated_label": "Community and Government > Education > College and University > College Auditorium",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12018": {
+    "integrated_label": "Community and Government > Education > College and University > College Baseball Diamond",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "12019": {
+    "integrated_label": "Community and Government > Education > College and University > College Basketball Court",
+    "single_match": {
+      "factual_category_id": "376",
+      "factual_category_label": "Sports and Recreation > Basketball",
+      "is_exact": false
+    }
+  },
+  "12020": {
+    "integrated_label": "Community and Government > Education > College and University > College Bookstore",
+    "single_match": {
+      "factual_category_id": "130",
+      "factual_category_label": "Retail > Bookstores",
+      "is_exact": false
+    }
+  },
+  "12021": {
+    "integrated_label": "Community and Government > Education > College and University > College Cafeteria",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12022": {
+    "integrated_label": "Community and Government > Education > College and University > College Classroom",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12023": {
+    "integrated_label": "Community and Government > Education > College and University > College Communications Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12024": {
+    "integrated_label": "Community and Government > Education > College and University > College Cricket Pitch",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "12025": {
+    "integrated_label": "Community and Government > Education > College and University > College Engineering Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12026": {
+    "integrated_label": "Community and Government > Education > College and University > College Football Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "12027": {
+    "integrated_label": "Community and Government > Education > College and University > College Gym",
+    "single_match": {
+      "factual_category_id": "385",
+      "factual_category_label": "Sports and Recreation > Gyms and Fitness Centers",
+      "is_exact": false
+    }
+  },
+  "12028": {
+    "integrated_label": "Community and Government > Education > College and University > College History Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12029": {
+    "integrated_label": "Community and Government > Education > College and University > College Hockey Rink",
+    "single_match": {
+      "factual_category_id": "386",
+      "factual_category_label": "Sports and Recreation > Hockey",
+      "is_exact": false
+    }
+  },
+  "12030": {
+    "integrated_label": "Community and Government > Education > College and University > College Lab",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12031": {
+    "integrated_label": "Community and Government > Education > College and University > College Library",
+    "single_match": {
+      "factual_category_id": "44",
+      "factual_category_label": "Community and Government > Libraries",
+      "is_exact": false
+    }
+  },
+  "12032": {
+    "integrated_label": "Community and Government > Education > College and University > College Math Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12033": {
+    "integrated_label": "Community and Government > Education > College and University > College Quad",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12034": {
+    "integrated_label": "Community and Government > Education > College and University > College Rec Center",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12035": {
+    "integrated_label": "Community and Government > Education > College and University > College Residence Hall",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12036": {
+    "integrated_label": "Community and Government > Education > College and University > College Science Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12037": {
+    "integrated_label": "Community and Government > Education > College and University > College Soccer Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "12038": {
+    "integrated_label": "Community and Government > Education > College and University > College Stadium",
+    "single_match": {
+      "factual_category_id": "406",
+      "factual_category_label": "Sports and Recreation > Stadiums and Arenas",
+      "is_exact": false
+    }
+  },
+  "12039": {
+    "integrated_label": "Community and Government > Education > College and University > College Technology Building",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12040": {
+    "integrated_label": "Community and Government > Education > College and University > College Tennis Court",
+    "single_match": {
+      "factual_category_id": "399",
+      "factual_category_label": "Sports and Recreation > Racquet Sports > Tennis",
+      "is_exact": false
+    }
+  },
+  "12041": {
+    "integrated_label": "Community and Government > Education > College and University > College Theater",
+    "single_match": {
+      "factual_category_id": "333",
+      "factual_category_label": "Social > Entertainment > Music and Show Venues",
+      "is_exact": false
+    }
+  },
+  "12042": {
+    "integrated_label": "Community and Government > Education > College and University > College Track",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "12043": {
+    "integrated_label": "Community and Government > Education > College and University > Fraternity House",
+    "single_match": {
+      "factual_category_id": "33",
+      "factual_category_label": "Community and Government > Education > Fraternities and Sororities",
+      "is_exact": false
+    }
+  },
+  "12044": {
+    "integrated_label": "Community and Government > Education > College and University > Law School",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12045": {
+    "integrated_label": "Community and Government > Education > College and University > Medical School",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12046": {
+    "integrated_label": "Community and Government > Education > College and University > Sorority House",
+    "single_match": {
+      "factual_category_id": "33",
+      "factual_category_label": "Community and Government > Education > Fraternities and Sororities",
+      "is_exact": false
+    }
+  },
+  "12047": {
+    "integrated_label": "Community and Government > Education > College and University > Student Center",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12048": {
+    "integrated_label": "Community and Government > Education > College and University > Community College",
+    "single_match": {
+      "factual_category_id": "29",
+      "factual_category_label": "Community and Government > Education > Colleges and Universities",
+      "is_exact": false
+    }
+  },
+  "12049": {
+    "integrated_label": "Community and Government > Education > Computer Training School",
+    "single_match": {
+      "factual_category_id": "30",
+      "factual_category_label": "Community and Government > Education > Computer Training",
+      "is_exact": true
+    }
+  },
+  "12050": {
+    "integrated_label": "Community and Government > Education > Culinary School",
+    "single_match": {
+      "factual_category_id": "31",
+      "factual_category_label": "Community and Government > Education > Culinary Lessons and Schools",
+      "is_exact": true
+    }
+  },
+  "12051": {
+    "integrated_label": "Community and Government > Education > Driving School",
+    "single_match": {
+      "factual_category_id": "32",
+      "factual_category_label": "Community and Government > Education > Driving Schools",
+      "is_exact": true
+    }
+  },
+  "12052": {
+    "integrated_label": "Community and Government > Education > Flight School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12053": {
+    "integrated_label": "Community and Government > Education > Language School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12054": {
+    "integrated_label": "Community and Government > Education > Music School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12055": {
+    "integrated_label": "Community and Government > Education > Nursery School",
+    "single_match": {
+      "factual_category_id": "23",
+      "factual_category_label": "Community and Government > Day Care and Preschools",
+      "is_exact": false
+    }
+  },
+  "12056": {
+    "integrated_label": "Community and Government > Education > Preschool",
+    "single_match": {
+      "factual_category_id": "23",
+      "factual_category_label": "Community and Government > Day Care and Preschools",
+      "is_exact": false
+    }
+  },
+  "12057": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School",
+    "single_match": {
+      "factual_category_id": "34",
+      "factual_category_label": "Community and Government > Education > Primary and Secondary Schools",
+      "is_exact": true
+    }
+  },
+  "12058": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > Elementary School",
+    "single_match": {
+      "factual_category_id": "34",
+      "factual_category_label": "Community and Government > Education > Primary and Secondary Schools",
+      "is_exact": false
+    }
+  },
+  "12059": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > High School",
+    "single_match": {
+      "factual_category_id": "34",
+      "factual_category_label": "Community and Government > Education > Primary and Secondary Schools",
+      "is_exact": false
+    }
+  },
+  "12060": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > Middle School",
+    "single_match": {
+      "factual_category_id": "34",
+      "factual_category_label": "Community and Government > Education > Primary and Secondary Schools",
+      "is_exact": false
+    }
+  },
+  "12061": {
+    "integrated_label": "Community and Government > Education > Private School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12062": {
+    "integrated_label": "Community and Government > Education > Religious School",
+    "single_match": {
+      "factual_category_id": "26",
+      "factual_category_label": "Community and Government > Education",
+      "is_exact": false
+    }
+  },
+  "12063": {
+    "integrated_label": "Community and Government > Education > Trade School",
+    "single_match": {
+      "factual_category_id": "36",
+      "factual_category_label": "Community and Government > Education > Vocational Schools",
+      "is_exact": true
+    }
+  },
+  "12064": {
+    "integrated_label": "Community and Government > Government Building",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "12065": {
+    "integrated_label": "Community and Government > Government Building > Capitol Building",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "12066": {
+    "integrated_label": "Community and Government > Government Building > City Hall",
+    "single_match": {
+      "factual_category_id": "477",
+      "factual_category_label": "Community and Government > City Halls",
+      "is_exact": true
+    }
+  },
+  "12067": {
+    "integrated_label": "Community and Government > Government Building > Courthouse",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "12068": {
+    "integrated_label": "Community and Government > Government Building > Embassy / Consulate",
+    "single_match": {
+      "factual_category_id": "453",
+      "factual_category_label": "Community and Government > Government Departments and Agencies > Embassies",
+      "is_exact": true
+    }
+  },
+  "12069": {
+    "integrated_label": "Community and Government > Government Building > Government Department / Agency",
+    "single_match": {
+      "factual_category_id": "37",
+      "factual_category_label": "Community and Government > Government Departments and Agencies",
+      "is_exact": true
+    }
+  },
+  "12070": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety",
+    "single_match": {
+      "factual_category_id": "40",
+      "factual_category_label": "Community and Government > Law Enforcement and Public Safety",
+      "is_exact": true
+    }
+  },
+  "12071": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Fire Station",
+    "single_match": {
+      "factual_category_id": "42",
+      "factual_category_label": "Community and Government > Law Enforcement and Public Safety > Fire Stations",
+      "is_exact": true
+    }
+  },
+  "12072": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Police Station",
+    "single_match": {
+      "factual_category_id": "43",
+      "factual_category_label": "Community and Government > Law Enforcement and Public Safety > Police Stations",
+      "is_exact": true
+    }
+  },
+  "12073": {
+    "integrated_label": "Community and Government > Government Building > Military",
+    "single_match": {
+      "factual_category_id": "45",
+      "factual_category_label": "Community and Government > Military",
+      "is_exact": true
+    }
+  },
+  "12074": {
+    "integrated_label": "Community and Government > Government Building > Military > Military Base",
+    "single_match": {
+      "factual_category_id": "46",
+      "factual_category_label": "Community and Government > Military > Bases",
+      "is_exact": true
+    }
+  },
+  "12075": {
+    "integrated_label": "Community and Government > Government Building > Post Office",
+    "single_match": {
+      "factual_category_id": "51",
+      "factual_category_label": "Community and Government > Post Offices",
+      "is_exact": true
+    }
+  },
+  "12076": {
+    "integrated_label": "Community and Government > Government Lobbyist",
+    "single_match": {
+      "factual_category_id": "38",
+      "factual_category_label": "Community and Government > Government Lobbyists",
+      "is_exact": true
+    }
+  },
+  "12077": {
+    "integrated_label": "Community and Government > Homeless Shelter",
+    "single_match": {
+      "factual_category_id": "39",
+      "factual_category_label": "Community and Government > Housing Assistance and Shelters",
+      "is_exact": false
+    }
+  },
+  "12078": {
+    "integrated_label": "Community and Government > Housing Authority",
+    "single_match": {
+      "factual_category_id": "39",
+      "factual_category_label": "Community and Government > Housing Assistance and Shelters",
+      "is_exact": false
+    }
+  },
+  "12079": {
+    "integrated_label": "Community and Government > Housing Development",
+    "single_match": {
+      "factual_category_id": "39",
+      "factual_category_label": "Community and Government > Housing Assistance and Shelters",
+      "is_exact": false
+    }
+  },
+  "12080": {
+    "integrated_label": "Community and Government > Library",
+    "single_match": {
+      "factual_category_id": "44",
+      "factual_category_label": "Community and Government > Libraries",
+      "is_exact": true
+    }
+  },
+  "12081": {
+    "integrated_label": "Community and Government > Observatory",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "12082": {
+    "integrated_label": "Community and Government > Organization",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": true
+    }
+  },
+  "12083": {
+    "integrated_label": "Community and Government > Organization > Charity",
+    "single_match": {
+      "factual_category_id": "48",
+      "factual_category_label": "Community and Government > Organizations and Associations > Charities and Non-Profits",
+      "is_exact": true
+    }
+  },
+  "12084": {
+    "integrated_label": "Community and Government > Organization > Club House",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "12085": {
+    "integrated_label": "Community and Government > Organization > Environmental Organization",
+    "single_match": {
+      "factual_category_id": "49",
+      "factual_category_label": "Community and Government > Organizations and Associations > Environmental",
+      "is_exact": true
+    }
+  },
+  "12086": {
+    "integrated_label": "Community and Government > Organization > Non-Profit Organization",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "12087": {
+    "integrated_label": "Community and Government > Organization > Social Services Organization",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "12088": {
+    "integrated_label": "Community and Government > Organization > Veterans' Organization",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "12089": {
+    "integrated_label": "Community and Government > Organization > Youth Organization",
+    "single_match": {
+      "factual_category_id": "50",
+      "factual_category_label": "Community and Government > Organizations and Associations > Youth Organizations",
+      "is_exact": true
+    }
+  },
+  "12090": {
+    "integrated_label": "Community and Government > Prison",
+    "single_match": {
+      "factual_category_id": "20",
+      "factual_category_label": "Community and Government",
+      "is_exact": false
+    }
+  },
+  "12091": {
+    "integrated_label": "Community and Government > Public and Social Service",
+    "single_match": {
+      "factual_category_id": "52",
+      "factual_category_label": "Community and Government > Public and Social Services",
+      "is_exact": true
+    }
+  },
+  "12092": {
+    "integrated_label": "Community and Government > Public Bathroom",
+    "single_match": {
+      "factual_category_id": "52",
+      "factual_category_label": "Community and Government > Public and Social Services",
+      "is_exact": false
+    }
+  },
+  "12093": {
+    "integrated_label": "Community and Government > Rehabilitation Center",
+    "single_match": {
+      "factual_category_id": "52",
+      "factual_category_label": "Community and Government > Public and Social Services",
+      "is_exact": false
+    }
+  },
+  "12094": {
+    "integrated_label": "Community and Government > Residential Building",
+    "single_match": {
+      "factual_category_id": "296",
+      "factual_category_label": "Businesses and Services > Real Estate > Apartments, Condos, and Houses",
+      "is_exact": true
+    }
+  },
+  "12095": {
+    "integrated_label": "Community and Government > Retirement Home",
+    "single_match": {
+      "factual_category_id": "60",
+      "factual_category_label": "Community and Government > Senior Citizen Services > Retirement",
+      "is_exact": true
+    }
+  },
+  "12096": {
+    "integrated_label": "Community and Government > Senior Citizen Service",
+    "single_match": {
+      "factual_category_id": "59",
+      "factual_category_label": "Community and Government > Senior Citizen Services",
+      "is_exact": true
+    }
+  },
+  "12097": {
+    "integrated_label": "Community and Government > Social Club",
+    "single_match": {
+      "factual_category_id": "47",
+      "factual_category_label": "Community and Government > Organizations and Associations",
+      "is_exact": false
+    }
+  },
+  "12098": {
+    "integrated_label": "Community and Government > Spiritual Center",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": true
+    }
+  },
+  "12099": {
+    "integrated_label": "Community and Government > Spiritual Center > Buddhist Temple",
+    "single_match": {
+      "factual_category_id": "54",
+      "factual_category_label": "Community and Government > Religious > Buddhist Temples",
+      "is_exact": true
+    }
+  },
+  "12100": {
+    "integrated_label": "Community and Government > Spiritual Center > Cemevi",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12101": {
+    "integrated_label": "Community and Government > Spiritual Center > Church",
+    "single_match": {
+      "factual_category_id": "55",
+      "factual_category_label": "Community and Government > Religious > Churches",
+      "is_exact": true
+    }
+  },
+  "12102": {
+    "integrated_label": "Community and Government > Spiritual Center > Confucian Temple",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12103": {
+    "integrated_label": "Community and Government > Spiritual Center > Hindu Temple",
+    "single_match": {
+      "factual_category_id": "56",
+      "factual_category_label": "Community and Government > Religious > Hindu Temples",
+      "is_exact": true
+    }
+  },
+  "12104": {
+    "integrated_label": "Community and Government > Spiritual Center > Kingdom Hall",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12105": {
+    "integrated_label": "Community and Government > Spiritual Center > Monastery",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12106": {
+    "integrated_label": "Community and Government > Spiritual Center > Mosque",
+    "single_match": {
+      "factual_category_id": "57",
+      "factual_category_label": "Community and Government > Religious > Mosques",
+      "is_exact": true
+    }
+  },
+  "12107": {
+    "integrated_label": "Community and Government > Spiritual Center > Prayer Room",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12108": {
+    "integrated_label": "Community and Government > Spiritual Center > Shrine",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12109": {
+    "integrated_label": "Community and Government > Spiritual Center > Sikh Temple",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12110": {
+    "integrated_label": "Community and Government > Spiritual Center > Synagogue",
+    "single_match": {
+      "factual_category_id": "58",
+      "factual_category_label": "Community and Government > Religious > Synagogues",
+      "is_exact": true
+    }
+  },
+  "12111": {
+    "integrated_label": "Community and Government > Spiritual Center > Temple",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12112": {
+    "integrated_label": "Community and Government > Spiritual Center > Terreiro",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12113": {
+    "integrated_label": "Community and Government > Summer Camp",
+    "single_match": {
+      "factual_category_id": "53",
+      "factual_category_label": "Community and Government > Religious",
+      "is_exact": false
+    }
+  },
+  "12114": {
+    "integrated_label": "Community and Government > Trailer Park",
+    "single_match": {
+      "factual_category_id": "255",
+      "factual_category_label": "Businesses and Services > Real Estate > Mobile Homes",
+      "is_exact": true
+    }
+  },
+  "12115": {
+    "integrated_label": "Community and Government > Utility Company",
+    "single_match": {
+      "factual_category_id": "61",
+      "factual_category_label": "Community and Government > Utility Companies",
+      "is_exact": true
+    }
+  },
+  "12116": {
+    "integrated_label": "Community and Government > Polling Place",
+    "single_match": {
+      "factual_category_id": "20",
+      "factual_category_label": "Community and Government",
+      "is_exact": false
+    }
+  },
+  "13000": {
+    "integrated_label": "Dining and Drinking",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": true
+    }
+  },
+  "13001": {
+    "integrated_label": "Dining and Drinking > Bagel Shop",
+    "single_match": {
+      "factual_category_id": "339",
+      "factual_category_label": "Social > Food and Dining > Bagels and Donuts",
+      "is_exact": false
+    }
+  },
+  "13002": {
+    "integrated_label": "Dining and Drinking > Bakery",
+    "single_match": {
+      "factual_category_id": "340",
+      "factual_category_label": "Social > Food and Dining > Bakeries",
+      "is_exact": true
+    }
+  },
+  "13003": {
+    "integrated_label": "Dining and Drinking > Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": true
+    }
+  },
+  "13004": {
+    "integrated_label": "Dining and Drinking > Bar > Apres Ski Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13005": {
+    "integrated_label": "Dining and Drinking > Bar > Beach Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13006": {
+    "integrated_label": "Dining and Drinking > Bar > Beer Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13007": {
+    "integrated_label": "Dining and Drinking > Bar > Beer Garden",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13008": {
+    "integrated_label": "Dining and Drinking > Bar > Champagne Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13009": {
+    "integrated_label": "Dining and Drinking > Bar > Cocktail Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13010": {
+    "integrated_label": "Dining and Drinking > Bar > Dive Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13011": {
+    "integrated_label": "Dining and Drinking > Bar > Gay Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13012": {
+    "integrated_label": "Dining and Drinking > Bar > Hookah Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13013": {
+    "integrated_label": "Dining and Drinking > Bar > Hotel Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13014": {
+    "integrated_label": "Dining and Drinking > Bar > Ice Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13015": {
+    "integrated_label": "Dining and Drinking > Bar > Karaoke Bar",
+    "single_match": {
+      "factual_category_id": "330",
+      "factual_category_label": "Social > Entertainment > Karaoke",
+      "is_exact": true
+    }
+  },
+  "13016": {
+    "integrated_label": "Dining and Drinking > Bar > Lounge",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13017": {
+    "integrated_label": "Dining and Drinking > Bar > Piano Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13018": {
+    "integrated_label": "Dining and Drinking > Bar > Pub",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13019": {
+    "integrated_label": "Dining and Drinking > Bar > Rooftop Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13020": {
+    "integrated_label": "Dining and Drinking > Bar > Sake Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13021": {
+    "integrated_label": "Dining and Drinking > Bar > Speakeasy",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13022": {
+    "integrated_label": "Dining and Drinking > Bar > Sports Bar",
+    "single_match": {
+      "factual_category_id": "315",
+      "factual_category_label": "Social > Bars > Sports Bars",
+      "is_exact": false
+    }
+  },
+  "13023": {
+    "integrated_label": "Dining and Drinking > Bar > Tiki Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13024": {
+    "integrated_label": "Dining and Drinking > Bar > Whisky Bar",
+    "single_match": {
+      "factual_category_id": "312",
+      "factual_category_label": "Social > Bars",
+      "is_exact": false
+    }
+  },
+  "13025": {
+    "integrated_label": "Dining and Drinking > Bar > Wine Bar",
+    "single_match": {
+      "factual_category_id": "316",
+      "factual_category_label": "Social > Bars > Wine Bars",
+      "is_exact": true
+    }
+  },
+  "13026": {
+    "integrated_label": "Dining and Drinking > Restaurant > BBQ Joint",
+    "single_match": {
+      "factual_category_id": "349",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Barbecue",
+      "is_exact": true
+    }
+  },
+  "13027": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bistro",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13028": {
+    "integrated_label": "Dining and Drinking > Breakfast Spot",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13029": {
+    "integrated_label": "Dining and Drinking > Brewery",
+    "single_match": {
+      "factual_category_id": "341",
+      "factual_category_label": "Social > Food and Dining > Breweries",
+      "is_exact": true
+    }
+  },
+  "13030": {
+    "integrated_label": "Dining and Drinking > Restaurant > Buffet",
+    "single_match": {
+      "factual_category_id": "350",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Buffets",
+      "is_exact": true
+    }
+  },
+  "13031": {
+    "integrated_label": "Dining and Drinking > Restaurant > Burger Joint",
+    "single_match": {
+      "factual_category_id": "351",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Burgers",
+      "is_exact": true
+    }
+  },
+  "13032": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": true
+    }
+  },
+  "13033": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Bubble Tea Shop",
+    "single_match": {
+      "factual_category_id": "482",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses > Bubble Tea",
+      "is_exact": true
+    }
+  },
+  "13034": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Café",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": false
+    }
+  },
+  "13035": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Coffee Shop",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": false
+    }
+  },
+  "13036": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Tea Room",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": false
+    }
+  },
+  "13037": {
+    "integrated_label": "Dining and Drinking > Cafeteria",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13038": {
+    "integrated_label": "Dining and Drinking > Cidery",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13039": {
+    "integrated_label": "Dining and Drinking > Restaurant > Deli",
+    "single_match": {
+      "factual_category_id": "353",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Delis",
+      "is_exact": true
+    }
+  },
+  "13040": {
+    "integrated_label": "Dining and Drinking > Dessert Shop",
+    "single_match": {
+      "factual_category_id": "343",
+      "factual_category_label": "Social > Food and Dining > Dessert",
+      "is_exact": true
+    }
+  },
+  "13041": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Creperie",
+    "single_match": {
+      "factual_category_id": "343",
+      "factual_category_label": "Social > Food and Dining > Dessert",
+      "is_exact": false
+    }
+  },
+  "13042": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Cupcake Shop",
+    "single_match": {
+      "factual_category_id": "343",
+      "factual_category_label": "Social > Food and Dining > Dessert",
+      "is_exact": false
+    }
+  },
+  "13043": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Donut Shop",
+    "single_match": {
+      "factual_category_id": "339",
+      "factual_category_label": "Social > Food and Dining > Bagels and Donuts",
+      "is_exact": false
+    }
+  },
+  "13044": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Frozen Yogurt Shop",
+    "single_match": {
+      "factual_category_id": "344",
+      "factual_category_label": "Social > Food and Dining > Ice Cream Parlors",
+      "is_exact": false
+    }
+  },
+  "13045": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Gelato Shop",
+    "single_match": {
+      "factual_category_id": "344",
+      "factual_category_label": "Social > Food and Dining > Ice Cream Parlors",
+      "is_exact": false
+    }
+  },
+  "13046": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Ice Cream Parlor",
+    "single_match": {
+      "factual_category_id": "344",
+      "factual_category_label": "Social > Food and Dining > Ice Cream Parlors",
+      "is_exact": true
+    }
+  },
+  "13047": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Pastry Shop",
+    "single_match": {
+      "factual_category_id": "343",
+      "factual_category_label": "Social > Food and Dining > Dessert",
+      "is_exact": false
+    }
+  },
+  "13048": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Pie Shop",
+    "single_match": {
+      "factual_category_id": "343",
+      "factual_category_label": "Social > Food and Dining > Dessert",
+      "is_exact": false
+    }
+  },
+  "13049": {
+    "integrated_label": "Dining and Drinking > Restaurant > Diner",
+    "single_match": {
+      "factual_category_id": "354",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Diners",
+      "is_exact": true
+    }
+  },
+  "13050": {
+    "integrated_label": "Dining and Drinking > Distillery",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13051": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fish and Chips Shop",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13052": {
+    "integrated_label": "Dining and Drinking > Food Court",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13053": {
+    "integrated_label": "Dining and Drinking > Food Stand",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13054": {
+    "integrated_label": "Dining and Drinking > Food Truck",
+    "single_match": {
+      "factual_category_id": "458",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Food Trucks",
+      "is_exact": true
+    }
+  },
+  "13055": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fried Chicken Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13056": {
+    "integrated_label": "Dining and Drinking > Restaurant > Friterie",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13057": {
+    "integrated_label": "Dining and Drinking > Restaurant > Gastropub",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13058": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hot Dog Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13059": {
+    "integrated_label": "Dining and Drinking > Juice Bar",
+    "single_match": {
+      "factual_category_id": "346",
+      "factual_category_label": "Social > Food and Dining > Juice Bars and Smoothies",
+      "is_exact": false
+    }
+  },
+  "13060": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mac and Cheese Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13061": {
+    "integrated_label": "Dining and Drinking > Meadery",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13062": {
+    "integrated_label": "Dining and Drinking > Night Market",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13063": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Pet Café",
+    "single_match": {
+      "factual_category_id": "342",
+      "factual_category_label": "Social > Food and Dining > Cafes, Coffee and Tea Houses",
+      "is_exact": false
+    }
+  },
+  "13064": {
+    "integrated_label": "Dining and Drinking > Restaurant > Pizzeria",
+    "single_match": {
+      "factual_category_id": "363",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Pizza",
+      "is_exact": true
+    }
+  },
+  "13065": {
+    "integrated_label": "Dining and Drinking > Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": true
+    }
+  },
+  "13066": {
+    "integrated_label": "Dining and Drinking > Restaurant > Afghan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13067": {
+    "integrated_label": "Dining and Drinking > Restaurant > African Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13068": {
+    "integrated_label": "Dining and Drinking > Restaurant > American Restaurant",
+    "single_match": {
+      "factual_category_id": "348",
+      "factual_category_label": "Social > Food and Dining > Restaurants > American",
+      "is_exact": true
+    }
+  },
+  "13069": {
+    "integrated_label": "Dining and Drinking > Restaurant > Arepa Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13070": {
+    "integrated_label": "Dining and Drinking > Restaurant > Argentinian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13071": {
+    "integrated_label": "Dining and Drinking > Restaurant > Armenian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13072": {
+    "integrated_label": "Dining and Drinking > Restaurant > Asian Restaurant",
+    "single_match": {
+      "factual_category_id": "457",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Asian",
+      "is_exact": true
+    }
+  },
+  "13073": {
+    "integrated_label": "Dining and Drinking > Restaurant > Australian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13074": {
+    "integrated_label": "Dining and Drinking > Restaurant > Austrian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13075": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bangladeshi Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13076": {
+    "integrated_label": "Dining and Drinking > Restaurant > Belarusian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13077": {
+    "integrated_label": "Dining and Drinking > Restaurant > Belgian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13078": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bosnian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13079": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13080": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Acai House",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13081": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Baiano Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13082": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Central Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13083": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Churrascaria",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13084": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Empada House",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13085": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Goiano Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13086": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Mineiro Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13087": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Northeastern Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13088": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Northern Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13089": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Pastelaria",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13090": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Southeastern Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13091": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Southern Brazilian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13092": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Tapiocaria",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13093": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bulgarian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13094": {
+    "integrated_label": "Dining and Drinking > Restaurant > Burmese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13095": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cajun / Creole Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13096": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cambodian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13097": {
+    "integrated_label": "Dining and Drinking > Restaurant > Caribbean Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13098": {
+    "integrated_label": "Dining and Drinking > Restaurant > Caucasian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13099": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": true
+    }
+  },
+  "13100": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Anhui Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13101": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Beijing Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13102": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Cantonese Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13103": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Cha Chaan Teng",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13104": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Chinese Aristocrat Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13105": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Chinese Breakfast Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13106": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Dim Sum Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13107": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Dongbei Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13108": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Fujian Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13109": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Guizhou Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13110": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hainan Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13111": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hakka Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13112": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Henan Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13113": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hong Kong Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13114": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Huaiyang Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13115": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hubei Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13116": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hunan Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13117": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Imperial Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13118": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Jiangsu Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13119": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Jiangxi Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13120": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Macanese Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13121": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Manchu Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13122": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Peking Duck Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13123": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shaanxi Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13124": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shandong Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13125": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shanghai Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13126": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shanxi Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13127": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Szechuan Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13128": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Taiwanese Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13129": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Tianjin Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13130": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Xinjiang Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13131": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Yunnan Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13132": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Zhejiang Restaurant",
+    "single_match": {
+      "factual_category_id": "352",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Chinese",
+      "is_exact": false
+    }
+  },
+  "13133": {
+    "integrated_label": "Dining and Drinking > Restaurant > Colombian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13134": {
+    "integrated_label": "Dining and Drinking > Restaurant > Comfort Food Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13135": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cuban Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13136": {
+    "integrated_label": "Dining and Drinking > Restaurant > Czech Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13137": {
+    "integrated_label": "Dining and Drinking > Restaurant > Dumpling Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13138": {
+    "integrated_label": "Dining and Drinking > Restaurant > Dutch Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13139": {
+    "integrated_label": "Dining and Drinking > Restaurant > Eastern European Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13140": {
+    "integrated_label": "Dining and Drinking > Restaurant > Egyptian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13141": {
+    "integrated_label": "Dining and Drinking > Restaurant > Empanada Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13142": {
+    "integrated_label": "Dining and Drinking > Restaurant > English Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13143": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ethiopian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13144": {
+    "integrated_label": "Dining and Drinking > Restaurant > Falafel Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13145": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fast Food Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13146": {
+    "integrated_label": "Dining and Drinking > Restaurant > Filipino Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13147": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fondue Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13148": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": true
+    }
+  },
+  "13149": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Alsatian Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13150": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Auvergne Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13151": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Basque Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13152": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Brasserie",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13153": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Breton Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13154": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Burgundian Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13155": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Catalan Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13156": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Ch'ti Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13157": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Corsican Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13158": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Estaminet",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13159": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Labour Canteen",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13160": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Lyonese Bouchon",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13161": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Norman Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13162": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Provençal Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13163": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Savoyard Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13164": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Southwestern French Restaurant",
+    "single_match": {
+      "factual_category_id": "356",
+      "factual_category_label": "Social > Food and Dining > Restaurants > French",
+      "is_exact": false
+    }
+  },
+  "13165": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13166": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Apple Wine Pub",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13167": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Bavarian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13168": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Bratwurst Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13169": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Currywurst Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13170": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Franconian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13171": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > German Pop-Up Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13172": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Palatine Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13173": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Rhenisch Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13174": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Schnitzel Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13175": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Silesian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13176": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Swabian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13177": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13178": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Bougatsa Shop",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13179": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Cretan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13180": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Fish Taverna",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13181": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Grilled Meat Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13182": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Kafenio",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13183": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Magirio",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13184": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Meze Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13185": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Modern Greek Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13186": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Ouzeri",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13187": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Patsa Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13188": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Souvlaki Shop",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13189": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Taverna",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13190": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Tsipouro Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13191": {
+    "integrated_label": "Dining and Drinking > Restaurant > Halal Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13192": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hawaiian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13193": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hawaiian Restaurant > Poke Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13194": {
+    "integrated_label": "Dining and Drinking > Restaurant > Himalayan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13195": {
+    "integrated_label": "Dining and Drinking > Restaurant > Honduran Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13196": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hotpot Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13197": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hungarian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13198": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Chinese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13199": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": true
+    }
+  },
+  "13200": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Andhra Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13201": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Awadhi Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13202": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Bengali Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13203": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Chaat Place",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13204": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Chettinad Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13205": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Dhaba",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13206": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Dosa Place",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13207": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Goan Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13208": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Gujarati Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13209": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Hyderabadi Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13210": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Indian Sweet Shop",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13211": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Irani Cafe",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13212": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Jain Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13213": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Karnataka Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13214": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Kerala Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13215": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Maharashtrian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13216": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Mughlai Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13217": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Multicuisine Indian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13218": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > North Indian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13219": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Northeast Indian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13220": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Parsi Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13221": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Punjabi Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13222": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Rajasthani Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13223": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > South Indian Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13224": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Udupi Restaurant",
+    "single_match": {
+      "factual_category_id": "357",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Indian",
+      "is_exact": false
+    }
+  },
+  "13225": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13226": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Acehnese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13227": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Balinese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13228": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Betawinese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13229": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Indonesian Meatball Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13230": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Javanese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13231": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Manadonese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13232": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Padangnese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13233": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Sundanese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13234": {
+    "integrated_label": "Dining and Drinking > Restaurant > Iraqi Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13235": {
+    "integrated_label": "Dining and Drinking > Restaurant > Israeli Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": true
+    }
+  },
+  "13236": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13237": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Abruzzo Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13238": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Agriturismo",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13239": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Aosta Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13240": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Basilicata Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13241": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Calabria Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13242": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Campanian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13243": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Emilia Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13244": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Friuli Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13245": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Ligurian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13246": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Lombard Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13247": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Malga",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13248": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Marche Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13249": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Molise Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13250": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Piadineria",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13251": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Piedmontese Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13252": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Puglia Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13253": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Romagna Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13254": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Roman Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13255": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Sardinian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13256": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Sicilian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13257": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > South Tyrolean Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13258": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Trattoria/Osteria",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13259": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Trentino Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13260": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Tuscan Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13261": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Umbrian Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13262": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Veneto Restaurant",
+    "single_match": {
+      "factual_category_id": "358",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Italian",
+      "is_exact": false
+    }
+  },
+  "13263": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": true
+    }
+  },
+  "13264": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Donburi Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13265": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Japanese Curry Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13266": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Japanese Family Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13267": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Kaiseki Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13268": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Kushikatsu Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13269": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Monjayaki Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13270": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Nabe Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13271": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Okonomiyaki Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13272": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Ramen Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13273": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Shabu-Shabu Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13274": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Soba Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13275": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Sukiyaki Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13276": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Sushi Restaurant",
+    "single_match": {
+      "factual_category_id": "366",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Sushi",
+      "is_exact": true
+    }
+  },
+  "13277": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Takoyaki Place",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13278": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Teishoku Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13279": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Tempura Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13280": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Tonkatsu Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13281": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Udon Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13282": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Unagi Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13283": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Wagashi Place",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13284": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Yakitori Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13285": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Yoshoku Restaurant",
+    "single_match": {
+      "factual_category_id": "359",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Japanese",
+      "is_exact": false
+    }
+  },
+  "13286": {
+    "integrated_label": "Dining and Drinking > Restaurant > Jewish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13287": {
+    "integrated_label": "Dining and Drinking > Restaurant > Jewish Restaurant > Kosher Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13288": {
+    "integrated_label": "Dining and Drinking > Restaurant > Kebab Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13289": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": true
+    }
+  },
+  "13290": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Bossam/Jokbal Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13291": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Bunsik Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13292": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Gukbap Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13293": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Janguh Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13294": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Korean BBQ Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13295": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Samgyetang Restaurant",
+    "single_match": {
+      "factual_category_id": "360",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Korean",
+      "is_exact": false
+    }
+  },
+  "13296": {
+    "integrated_label": "Dining and Drinking > Restaurant > Kurdish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13297": {
+    "integrated_label": "Dining and Drinking > Restaurant > Latin American Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13298": {
+    "integrated_label": "Dining and Drinking > Restaurant > Lebanese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13299": {
+    "integrated_label": "Dining and Drinking > Restaurant > Malay Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13300": {
+    "integrated_label": "Dining and Drinking > Restaurant > Malay Restaurant > Mamak Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13301": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mauritian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13302": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mediterranean Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13303": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": true
+    }
+  },
+  "13304": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Botanero",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": false
+    }
+  },
+  "13305": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Burrito Restaurant",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": false
+    }
+  },
+  "13306": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Taco Restaurant",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": false
+    }
+  },
+  "13307": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Tex-Mex Restaurant",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": false
+    }
+  },
+  "13308": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Yucatecan Restaurant",
+    "single_match": {
+      "factual_category_id": "361",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Mexican",
+      "is_exact": false
+    }
+  },
+  "13309": {
+    "integrated_label": "Dining and Drinking > Restaurant > Middle Eastern Restaurant",
+    "single_match": {
+      "factual_category_id": "362",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Middle Eastern",
+      "is_exact": true
+    }
+  },
+  "13310": {
+    "integrated_label": "Dining and Drinking > Restaurant > Modern European Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13311": {
+    "integrated_label": "Dining and Drinking > Restaurant > Molecular Gastronomy Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13312": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mongolian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13313": {
+    "integrated_label": "Dining and Drinking > Restaurant > Moroccan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13314": {
+    "integrated_label": "Dining and Drinking > Restaurant > New American Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13315": {
+    "integrated_label": "Dining and Drinking > Restaurant > Noodle Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13316": {
+    "integrated_label": "Dining and Drinking > Restaurant > Pakistani Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13317": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13318": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Ash and Haleem Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13319": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Dizi Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13320": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Gilaki Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13321": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Jegaraki",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13322": {
+    "integrated_label": "Dining and Drinking > Restaurant > Peruvian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13323": {
+    "integrated_label": "Dining and Drinking > Restaurant > Peruvian Restaurant > Peruvian Roast Chicken Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13324": {
+    "integrated_label": "Dining and Drinking > Restaurant > Polish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13325": {
+    "integrated_label": "Dining and Drinking > Restaurant > Portuguese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13326": {
+    "integrated_label": "Dining and Drinking > Restaurant > Poutine Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13327": {
+    "integrated_label": "Dining and Drinking > Restaurant > Puerto Rican Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13328": {
+    "integrated_label": "Dining and Drinking > Restaurant > Romanian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13329": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13330": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant > Blini House",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13331": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant > Pelmeni House",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13332": {
+    "integrated_label": "Dining and Drinking > Restaurant > Salad Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13333": {
+    "integrated_label": "Dining and Drinking > Restaurant > Salvadoran Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13334": {
+    "integrated_label": "Dining and Drinking > Restaurant > Sandwich Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13335": {
+    "integrated_label": "Dining and Drinking > Restaurant > Satay Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13336": {
+    "integrated_label": "Dining and Drinking > Restaurant > Scandinavian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13337": {
+    "integrated_label": "Dining and Drinking > Restaurant > Scottish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13338": {
+    "integrated_label": "Dining and Drinking > Restaurant > Seafood Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13339": {
+    "integrated_label": "Dining and Drinking > Restaurant > Shawarma Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13340": {
+    "integrated_label": "Dining and Drinking > Restaurant > Singaporean Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13341": {
+    "integrated_label": "Dining and Drinking > Restaurant > Slovak Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13342": {
+    "integrated_label": "Dining and Drinking > Restaurant > Soup Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13343": {
+    "integrated_label": "Dining and Drinking > Restaurant > South American Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13344": {
+    "integrated_label": "Dining and Drinking > Restaurant > Southern / Soul Food Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13345": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13346": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant > Paella Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13347": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant > Tapas Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13348": {
+    "integrated_label": "Dining and Drinking > Restaurant > Sri Lankan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13349": {
+    "integrated_label": "Dining and Drinking > Restaurant > Swiss Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13350": {
+    "integrated_label": "Dining and Drinking > Restaurant > Syrian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13351": {
+    "integrated_label": "Dining and Drinking > Restaurant > Tatar Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13352": {
+    "integrated_label": "Dining and Drinking > Restaurant > Thai Restaurant",
+    "single_match": {
+      "factual_category_id": "367",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Thai",
+      "is_exact": true
+    }
+  },
+  "13353": {
+    "integrated_label": "Dining and Drinking > Restaurant > Thai Restaurant > Som Tum Restaurant",
+    "single_match": {
+      "factual_category_id": "367",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Thai",
+      "is_exact": false
+    }
+  },
+  "13354": {
+    "integrated_label": "Dining and Drinking > Restaurant > Theme Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13355": {
+    "integrated_label": "Dining and Drinking > Restaurant > Tibetan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13356": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13357": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Borek Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13358": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Cigkofte Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13359": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Çöp Şiş Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13360": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Doner Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13361": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Gozleme Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13362": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kofte Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13363": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kokoreç Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13364": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kumpir Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13365": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kumru Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13366": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Manti Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13367": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Meyhane",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13368": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Pide Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13369": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Pilavcı",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13370": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Söğüş Place",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13371": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Tantuni Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13372": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Turkish Coffeehouse",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13373": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Turkish Home Cooking Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13374": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13375": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant > Varenyky Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13376": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant > West-Ukrainian Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13377": {
+    "integrated_label": "Dining and Drinking > Restaurant > Vegan and Vegetarian Restaurant",
+    "single_match": {
+      "factual_category_id": "368",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Vegan and Vegetarian",
+      "is_exact": true
+    }
+  },
+  "13378": {
+    "integrated_label": "Dining and Drinking > Restaurant > Venezuelan Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13379": {
+    "integrated_label": "Dining and Drinking > Restaurant > Vietnamese Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13380": {
+    "integrated_label": "Dining and Drinking > Restaurant > Yemeni Restaurant",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13381": {
+    "integrated_label": "Dining and Drinking > Smoothie Shop",
+    "single_match": {
+      "factual_category_id": "346",
+      "factual_category_label": "Social > Food and Dining > Juice Bars and Smoothies",
+      "is_exact": false
+    }
+  },
+  "13382": {
+    "integrated_label": "Dining and Drinking > Snack Place",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13383": {
+    "integrated_label": "Dining and Drinking > Restaurant > Steakhouse",
+    "single_match": {
+      "factual_category_id": "365",
+      "factual_category_label": "Social > Food and Dining > Restaurants > Steakhouses",
+      "is_exact": true
+    }
+  },
+  "13384": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Tabbakhi",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "13385": {
+    "integrated_label": "Dining and Drinking > Truck Stop",
+    "single_match": {
+      "factual_category_id": "338",
+      "factual_category_label": "Social > Food and Dining",
+      "is_exact": false
+    }
+  },
+  "13386": {
+    "integrated_label": "Dining and Drinking > Vineyard",
+    "single_match": {
+      "factual_category_id": "370",
+      "factual_category_label": "Social > Wineries and Vineyards",
+      "is_exact": false
+    }
+  },
+  "13387": {
+    "integrated_label": "Dining and Drinking > Winery",
+    "single_match": {
+      "factual_category_id": "370",
+      "factual_category_label": "Social > Wineries and Vineyards",
+      "is_exact": false
+    }
+  },
+  "13388": {
+    "integrated_label": "Dining and Drinking > Restaurant > Wings Joint",
+    "single_match": {
+      "factual_category_id": "347",
+      "factual_category_label": "Social > Food and Dining > Restaurants",
+      "is_exact": false
+    }
+  },
+  "14000": {
+    "integrated_label": "Event",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14001": {
+    "integrated_label": "Event > Conference",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14002": {
+    "integrated_label": "Event > Convention",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14003": {
+    "integrated_label": "Event > Entertainment Event",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14004": {
+    "integrated_label": "Event > Entertainment Event > Festival",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14005": {
+    "integrated_label": "Event > Entertainment Event > Music Festival",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14006": {
+    "integrated_label": "Event > Entertainment Event > Parade",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14007": {
+    "integrated_label": "Event > Entertainment Event > Sporting Event",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14008": {
+    "integrated_label": "Event > Line / Queue",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14009": {
+    "integrated_label": "Event > Marketplace",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14010": {
+    "integrated_label": "Event > Marketplace > Christmas Market",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14011": {
+    "integrated_label": "Event > Marketplace > Stoop Sale",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14012": {
+    "integrated_label": "Event > Marketplace > Street Fair",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14013": {
+    "integrated_label": "Event > Marketplace > Street Food Gathering",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14014": {
+    "integrated_label": "Event > Marketplace > Trade Fair",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "14015": {
+    "integrated_label": "Event > Other Event",
+    "single_match": {
+      "factual_category_id": "217",
+      "factual_category_label": "Businesses and Services > Events and Event Planning",
+      "is_exact": false
+    }
+  },
+  "15000": {
+    "integrated_label": "Health and Medicine",
+    "single_match": {
+      "factual_category_id": "62",
+      "factual_category_label": "Healthcare",
+      "is_exact": true
+    }
+  },
+  "15001": {
+    "integrated_label": "Health and Medicine > Acupuncture Clinic",
+    "single_match": {
+      "factual_category_id": "73",
+      "factual_category_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine > Acupuncture",
+      "is_exact": true
+    }
+  },
+  "15002": {
+    "integrated_label": "Health and Medicine > AIDS Resource",
+    "single_match": {
+      "factual_category_id": "63",
+      "factual_category_label": "Healthcare > AIDS Resources",
+      "is_exact": true
+    }
+  },
+  "15003": {
+    "integrated_label": "Health and Medicine > Alternative Medicine Clinic",
+    "single_match": {
+      "factual_category_id": "72",
+      "factual_category_label": "Healthcare > Holistic, Alternative and Naturopathic Medicine",
+      "is_exact": true
+    }
+  },
+  "15004": {
+    "integrated_label": "Health and Medicine > Assisted Living Service",
+    "single_match": {
+      "factual_category_id": "64",
+      "factual_category_label": "Healthcare > Assisted Living Services",
+      "is_exact": true
+    }
+  },
+  "15005": {
+    "integrated_label": "Health and Medicine > Blood Bank",
+    "single_match": {
+      "factual_category_id": "67",
+      "factual_category_label": "Healthcare > Blood Banks and Centers",
+      "is_exact": true
+    }
+  },
+  "15006": {
+    "integrated_label": "Health and Medicine > Chiropractor",
+    "single_match": {
+      "factual_category_id": "68",
+      "factual_category_label": "Healthcare > Chiropractors",
+      "is_exact": true
+    }
+  },
+  "15007": {
+    "integrated_label": "Health and Medicine > Dentist",
+    "single_match": {
+      "factual_category_id": "69",
+      "factual_category_label": "Healthcare > Dentists",
+      "is_exact": true
+    }
+  },
+  "15008": {
+    "integrated_label": "Health and Medicine > Emergency Service",
+    "single_match": {
+      "factual_category_id": "70",
+      "factual_category_label": "Healthcare > Emergency Services",
+      "is_exact": true
+    }
+  },
+  "15009": {
+    "integrated_label": "Health and Medicine > Emergency Service > Ambulance Service",
+    "single_match": {
+      "factual_category_id": "71",
+      "factual_category_label": "Healthcare > Emergency Services > Ambulance",
+      "is_exact": true
+    }
+  },
+  "15010": {
+    "integrated_label": "Health and Medicine > Emergency Service > Emergency Room",
+    "single_match": {
+      "factual_category_id": "70",
+      "factual_category_label": "Healthcare > Emergency Services",
+      "is_exact": false
+    }
+  },
+  "15011": {
+    "integrated_label": "Health and Medicine > Healthcare Clinic",
+    "single_match": {
+      "factual_category_id": "74",
+      "factual_category_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+      "is_exact": false
+    }
+  },
+  "15012": {
+    "integrated_label": "Health and Medicine > Home Health Care Service",
+    "single_match": {
+      "factual_category_id": "65",
+      "factual_category_label": "Healthcare > Home Health Care Services",
+      "is_exact": true
+    }
+  },
+  "15013": {
+    "integrated_label": "Health and Medicine > Hospice",
+    "single_match": {
+      "factual_category_id": "62",
+      "factual_category_label": "Healthcare",
+      "is_exact": false
+    }
+  },
+  "15014": {
+    "integrated_label": "Health and Medicine > Hospital",
+    "single_match": {
+      "factual_category_id": "74",
+      "factual_category_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+      "is_exact": false
+    }
+  },
+  "15015": {
+    "integrated_label": "Health and Medicine > Maternity Clinic",
+    "single_match": {
+      "factual_category_id": "105",
+      "factual_category_label": "Healthcare > Pregnancy and Sexual Health",
+      "is_exact": true
+    }
+  },
+  "15016": {
+    "integrated_label": "Health and Medicine > Medical Center",
+    "single_match": {
+      "factual_category_id": "74",
+      "factual_category_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+      "is_exact": false
+    }
+  },
+  "15017": {
+    "integrated_label": "Health and Medicine > Medical Lab",
+    "single_match": {
+      "factual_category_id": "75",
+      "factual_category_label": "Healthcare > Medical Supplies and Labs",
+      "is_exact": false
+    }
+  },
+  "15018": {
+    "integrated_label": "Health and Medicine > Mental Health Service",
+    "single_match": {
+      "factual_category_id": "76",
+      "factual_category_label": "Healthcare > Mental Health",
+      "is_exact": true
+    }
+  },
+  "15019": {
+    "integrated_label": "Health and Medicine > Mental Health Service > Mental Health Clinic",
+    "single_match": {
+      "factual_category_id": "77",
+      "factual_category_label": "Healthcare > Mental Health > Counseling and Therapy",
+      "is_exact": true
+    }
+  },
+  "15020": {
+    "integrated_label": "Health and Medicine > Mental Health Service > Psychologist",
+    "single_match": {
+      "factual_category_id": "78",
+      "factual_category_label": "Healthcare > Mental Health > Psychologists",
+      "is_exact": true
+    }
+  },
+  "15021": {
+    "integrated_label": "Health and Medicine > Nurse",
+    "single_match": {
+      "factual_category_id": "79",
+      "factual_category_label": "Healthcare > Nurses",
+      "is_exact": true
+    }
+  },
+  "15022": {
+    "integrated_label": "Health and Medicine > Nursing Home",
+    "single_match": {
+      "factual_category_id": "66",
+      "factual_category_label": "Healthcare > Assisted Living Services > Facilities and Nursing Homes",
+      "is_exact": true
+    }
+  },
+  "15023": {
+    "integrated_label": "Health and Medicine > Nutritionist",
+    "single_match": {
+      "factual_category_id": "106",
+      "factual_category_label": "Healthcare > Weight Loss and Nutritionists",
+      "is_exact": false
+    }
+  },
+  "15024": {
+    "integrated_label": "Health and Medicine > Optometrist",
+    "single_match": {
+      "factual_category_id": "466",
+      "factual_category_label": "Healthcare > Optometrist",
+      "is_exact": true
+    }
+  },
+  "15025": {
+    "integrated_label": "Health and Medicine > Other Healthcare Professional",
+    "single_match": {
+      "factual_category_id": "475",
+      "factual_category_label": "Healthcare > Other Healthcare Professionals",
+      "is_exact": true
+    }
+  },
+  "15026": {
+    "integrated_label": "Health and Medicine > Physical Therapy Clinic",
+    "single_match": {
+      "factual_category_id": "81",
+      "factual_category_label": "Healthcare > Physical Therapy and Rehabilitation",
+      "is_exact": true
+    }
+  },
+  "15027": {
+    "integrated_label": "Health and Medicine > Physician",
+    "single_match": {
+      "factual_category_id": "83",
+      "factual_category_label": "Healthcare > Physicians",
+      "is_exact": true
+    }
+  },
+  "15028": {
+    "integrated_label": "Health and Medicine > Physician > Anesthesiologist",
+    "single_match": {
+      "factual_category_id": "84",
+      "factual_category_label": "Healthcare > Physicians > Anesthesiologists",
+      "is_exact": true
+    }
+  },
+  "15029": {
+    "integrated_label": "Health and Medicine > Physician > Cardiologist",
+    "single_match": {
+      "factual_category_id": "85",
+      "factual_category_label": "Healthcare > Physicians > Cardiologists",
+      "is_exact": true
+    }
+  },
+  "15030": {
+    "integrated_label": "Health and Medicine > Physician > Dermatologist",
+    "single_match": {
+      "factual_category_id": "86",
+      "factual_category_label": "Healthcare > Physicians > Dermatologists",
+      "is_exact": true
+    }
+  },
+  "15031": {
+    "integrated_label": "Health and Medicine > Physician > Doctor's Office",
+    "single_match": {
+      "factual_category_id": "83",
+      "factual_category_label": "Healthcare > Physicians",
+      "is_exact": false
+    }
+  },
+  "15032": {
+    "integrated_label": "Health and Medicine > Physician > Ear, Nose and Throat Doctor",
+    "single_match": {
+      "factual_category_id": "87",
+      "factual_category_label": "Healthcare > Physicians > Ear, Nose and Throat",
+      "is_exact": true
+    }
+  },
+  "15033": {
+    "integrated_label": "Health and Medicine > Physician > Family Medicine Doctor",
+    "single_match": {
+      "factual_category_id": "88",
+      "factual_category_label": "Healthcare > Physicians > Family Medicine",
+      "is_exact": true
+    }
+  },
+  "15034": {
+    "integrated_label": "Health and Medicine > Physician > Gastroenterologist",
+    "single_match": {
+      "factual_category_id": "89",
+      "factual_category_label": "Healthcare > Physicians > Gastroenterologists",
+      "is_exact": true
+    }
+  },
+  "15035": {
+    "integrated_label": "Health and Medicine > Physician > General Surgeon",
+    "single_match": {
+      "factual_category_id": "90",
+      "factual_category_label": "Healthcare > Physicians > General Surgery",
+      "is_exact": true
+    }
+  },
+  "15036": {
+    "integrated_label": "Health and Medicine > Physician > Geriatric Doctor",
+    "single_match": {
+      "factual_category_id": "441",
+      "factual_category_label": "Healthcare > Physicians > Geriatrics",
+      "is_exact": true
+    }
+  },
+  "15037": {
+    "integrated_label": "Health and Medicine > Physician > Internal Medicine Doctor",
+    "single_match": {
+      "factual_category_id": "91",
+      "factual_category_label": "Healthcare > Physicians > Internal Medicine",
+      "is_exact": true
+    }
+  },
+  "15038": {
+    "integrated_label": "Health and Medicine > Physician > Neurologist",
+    "single_match": {
+      "factual_category_id": "92",
+      "factual_category_label": "Healthcare > Physicians > Neurologists",
+      "is_exact": true
+    }
+  },
+  "15039": {
+    "integrated_label": "Health and Medicine > Physician > Obstetrician Gynecologist (Ob-gyn)",
+    "single_match": {
+      "factual_category_id": "93",
+      "factual_category_label": "Healthcare > Physicians > Obstetricians and Gynecologists",
+      "is_exact": true
+    }
+  },
+  "15040": {
+    "integrated_label": "Health and Medicine > Physician > Oncologist",
+    "single_match": {
+      "factual_category_id": "94",
+      "factual_category_label": "Healthcare > Physicians > Oncologists",
+      "is_exact": true
+    }
+  },
+  "15041": {
+    "integrated_label": "Health and Medicine > Physician > Ophthalmologist",
+    "single_match": {
+      "factual_category_id": "95",
+      "factual_category_label": "Healthcare > Physicians > Ophthalmologists",
+      "is_exact": true
+    }
+  },
+  "15042": {
+    "integrated_label": "Health and Medicine > Physician > Oral Surgeon",
+    "single_match": {
+      "factual_category_id": "476",
+      "factual_category_label": "Healthcare > Physicians > Oral Surgeons",
+      "is_exact": true
+    }
+  },
+  "15043": {
+    "integrated_label": "Health and Medicine > Physician > Orthopedic Surgeon",
+    "single_match": {
+      "factual_category_id": "96",
+      "factual_category_label": "Healthcare > Physicians > Orthopedic Surgeons",
+      "is_exact": true
+    }
+  },
+  "15044": {
+    "integrated_label": "Health and Medicine > Physician > Pathologist",
+    "single_match": {
+      "factual_category_id": "97",
+      "factual_category_label": "Healthcare > Physicians > Pathologists",
+      "is_exact": true
+    }
+  },
+  "15045": {
+    "integrated_label": "Health and Medicine > Physician > Pediatrician",
+    "single_match": {
+      "factual_category_id": "98",
+      "factual_category_label": "Healthcare > Physicians > Pediatricians",
+      "is_exact": true
+    }
+  },
+  "15046": {
+    "integrated_label": "Health and Medicine > Physician > Plastic Surgeon",
+    "single_match": {
+      "factual_category_id": "99",
+      "factual_category_label": "Healthcare > Physicians > Plastic Surgeons",
+      "is_exact": true
+    }
+  },
+  "15047": {
+    "integrated_label": "Health and Medicine > Physician > Psychiatrist",
+    "single_match": {
+      "factual_category_id": "100",
+      "factual_category_label": "Healthcare > Physicians > Psychiatrists",
+      "is_exact": true
+    }
+  },
+  "15048": {
+    "integrated_label": "Health and Medicine > Physician > Radiologist",
+    "single_match": {
+      "factual_category_id": "101",
+      "factual_category_label": "Healthcare > Physicians > Radiologists",
+      "is_exact": true
+    }
+  },
+  "15049": {
+    "integrated_label": "Health and Medicine > Physician > Respiratory Doctor",
+    "single_match": {
+      "factual_category_id": "102",
+      "factual_category_label": "Healthcare > Physicians > Respiratory",
+      "is_exact": true
+    }
+  },
+  "15050": {
+    "integrated_label": "Health and Medicine > Physician > Urologist",
+    "single_match": {
+      "factual_category_id": "103",
+      "factual_category_label": "Healthcare > Physicians > Urologists",
+      "is_exact": true
+    }
+  },
+  "15051": {
+    "integrated_label": "Health and Medicine > Podiatrist",
+    "single_match": {
+      "factual_category_id": "104",
+      "factual_category_label": "Healthcare > Podiatrists",
+      "is_exact": true
+    }
+  },
+  "15052": {
+    "integrated_label": "Health and Medicine > Sports Medicine Clinic",
+    "single_match": {
+      "factual_category_id": "82",
+      "factual_category_label": "Healthcare > Physical Therapy and Rehabilitation > Sports Medicine",
+      "is_exact": true
+    }
+  },
+  "15053": {
+    "integrated_label": "Health and Medicine > Urgent Care Center",
+    "single_match": {
+      "factual_category_id": "74",
+      "factual_category_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+      "is_exact": false
+    }
+  },
+  "15054": {
+    "integrated_label": "Health and Medicine > Veterinarian",
+    "single_match": {
+      "factual_category_id": "305",
+      "factual_category_label": "Businesses and Services > Veterinarians",
+      "is_exact": true
+    }
+  },
+  "15055": {
+    "integrated_label": "Health and Medicine > Weight Loss Center",
+    "single_match": {
+      "factual_category_id": "106",
+      "factual_category_label": "Healthcare > Weight Loss and Nutritionists",
+      "is_exact": false
+    }
+  },
+  "15056": {
+    "integrated_label": "Health and Medicine > Women's Health Clinic",
+    "single_match": {
+      "factual_category_id": "74",
+      "factual_category_label": "Healthcare > Hospitals, Clinics and Medical Centers",
+      "is_exact": false
+    }
+  },
+  "16000": {
+    "integrated_label": "Landmarks and Outdoors",
+    "single_match": {
+      "factual_category_id": "107",
+      "factual_category_label": "Landmarks",
+      "is_exact": true
+    }
+  },
+  "16001": {
+    "integrated_label": "Landmarks and Outdoors > Bathing Area",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16002": {
+    "integrated_label": "Landmarks and Outdoors > Bay",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16003": {
+    "integrated_label": "Landmarks and Outdoors > Beach",
+    "single_match": {
+      "factual_category_id": "113",
+      "factual_category_label": "Landmarks > Natural > Beaches",
+      "is_exact": true
+    }
+  },
+  "16004": {
+    "integrated_label": "Landmarks and Outdoors > Bike Trail",
+    "single_match": {
+      "factual_category_id": "378",
+      "factual_category_label": "Sports and Recreation > Cycling",
+      "is_exact": false
+    }
+  },
+  "16005": {
+    "integrated_label": "Landmarks and Outdoors > Botanical Garden",
+    "single_match": {
+      "factual_category_id": "109",
+      "factual_category_label": "Landmarks > Gardens",
+      "is_exact": false
+    }
+  },
+  "16006": {
+    "integrated_label": "Landmarks and Outdoors > Bridge",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16007": {
+    "integrated_label": "Landmarks and Outdoors > Building / Structure",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": true
+    }
+  },
+  "16008": {
+    "integrated_label": "Landmarks and Outdoors > Campground",
+    "single_match": {
+      "factual_category_id": "388",
+      "factual_category_label": "Sports and Recreation > Outdoors > Campgrounds and RV Parks",
+      "is_exact": false
+    }
+  },
+  "16009": {
+    "integrated_label": "Landmarks and Outdoors > Canal",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16010": {
+    "integrated_label": "Landmarks and Outdoors > Canal Lock",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16011": {
+    "integrated_label": "Landmarks and Outdoors > Castle",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16012": {
+    "integrated_label": "Landmarks and Outdoors > Cave",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16013": {
+    "integrated_label": "Landmarks and Outdoors > Dive Spot",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16014": {
+    "integrated_label": "Landmarks and Outdoors > Farm",
+    "single_match": {
+      "factual_category_id": "107",
+      "factual_category_label": "Landmarks",
+      "is_exact": false
+    }
+  },
+  "16015": {
+    "integrated_label": "Landmarks and Outdoors > Forest",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16016": {
+    "integrated_label": "Landmarks and Outdoors > Fountain",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16017": {
+    "integrated_label": "Landmarks and Outdoors > Garden",
+    "single_match": {
+      "factual_category_id": "109",
+      "factual_category_label": "Landmarks > Gardens",
+      "is_exact": true
+    }
+  },
+  "16018": {
+    "integrated_label": "Landmarks and Outdoors > Harbor / Marina",
+    "single_match": {
+      "factual_category_id": "107",
+      "factual_category_label": "Landmarks",
+      "is_exact": false
+    }
+  },
+  "16019": {
+    "integrated_label": "Landmarks and Outdoors > Hiking Trail",
+    "single_match": {
+      "factual_category_id": "389",
+      "factual_category_label": "Sports and Recreation > Outdoors > Hiking",
+      "is_exact": true
+    }
+  },
+  "16020": {
+    "integrated_label": "Landmarks and Outdoors > Historic and Protected Site",
+    "single_match": {
+      "factual_category_id": "110",
+      "factual_category_label": "Landmarks > Historic and Protected Sites",
+      "is_exact": true
+    }
+  },
+  "16021": {
+    "integrated_label": "Landmarks and Outdoors > Hot Spring",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16022": {
+    "integrated_label": "Landmarks and Outdoors > Island",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16023": {
+    "integrated_label": "Landmarks and Outdoors > Lake",
+    "single_match": {
+      "factual_category_id": "116",
+      "factual_category_label": "Landmarks > Natural > Lakes",
+      "is_exact": true
+    }
+  },
+  "16024": {
+    "integrated_label": "Landmarks and Outdoors > Lighthouse",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16025": {
+    "integrated_label": "Landmarks and Outdoors > Memorial Site",
+    "single_match": {
+      "factual_category_id": "111",
+      "factual_category_label": "Landmarks > Monuments and Memorials",
+      "is_exact": false
+    }
+  },
+  "16026": {
+    "integrated_label": "Landmarks and Outdoors > Monument",
+    "single_match": {
+      "factual_category_id": "111",
+      "factual_category_label": "Landmarks > Monuments and Memorials",
+      "is_exact": false
+    }
+  },
+  "16027": {
+    "integrated_label": "Landmarks and Outdoors > Mountain",
+    "single_match": {
+      "factual_category_id": "114",
+      "factual_category_label": "Landmarks > Natural > Mountains",
+      "is_exact": true
+    }
+  },
+  "16028": {
+    "integrated_label": "Landmarks and Outdoors > Nature Preserve",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16029": {
+    "integrated_label": "Landmarks and Outdoors > Nudist Beach",
+    "single_match": {
+      "factual_category_id": "113",
+      "factual_category_label": "Landmarks > Natural > Beaches",
+      "is_exact": false
+    }
+  },
+  "16030": {
+    "integrated_label": "Landmarks and Outdoors > Other Great Outdoors",
+    "single_match": {
+      "factual_category_id": "387",
+      "factual_category_label": "Sports and Recreation > Outdoors",
+      "is_exact": false
+    }
+  },
+  "16031": {
+    "integrated_label": "Landmarks and Outdoors > Palace",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16032": {
+    "integrated_label": "Landmarks and Outdoors > Park",
+    "single_match": {
+      "factual_category_id": "118",
+      "factual_category_label": "Landmarks > Parks",
+      "is_exact": true
+    }
+  },
+  "16033": {
+    "integrated_label": "Landmarks and Outdoors > Park > Dog Park",
+    "single_match": {
+      "factual_category_id": "461",
+      "factual_category_label": "Landmarks > Parks > Dog Parks",
+      "is_exact": true
+    }
+  },
+  "16034": {
+    "integrated_label": "Landmarks and Outdoors > Park > National Park",
+    "single_match": {
+      "factual_category_id": "118",
+      "factual_category_label": "Landmarks > Parks",
+      "is_exact": false
+    }
+  },
+  "16035": {
+    "integrated_label": "Landmarks and Outdoors > Park > Natural Park",
+    "single_match": {
+      "factual_category_id": "119",
+      "factual_category_label": "Landmarks > Parks > Natural Parks",
+      "is_exact": true
+    }
+  },
+  "16036": {
+    "integrated_label": "Landmarks and Outdoors > Park > Picnic Area",
+    "single_match": {
+      "factual_category_id": "118",
+      "factual_category_label": "Landmarks > Parks",
+      "is_exact": false
+    }
+  },
+  "16037": {
+    "integrated_label": "Landmarks and Outdoors > Park > Playground",
+    "single_match": {
+      "factual_category_id": "118",
+      "factual_category_label": "Landmarks > Parks",
+      "is_exact": false
+    }
+  },
+  "16038": {
+    "integrated_label": "Landmarks and Outdoors > Park > State / Provincial Park",
+    "single_match": {
+      "factual_category_id": "118",
+      "factual_category_label": "Landmarks > Parks",
+      "is_exact": false
+    }
+  },
+  "16039": {
+    "integrated_label": "Landmarks and Outdoors > Park > Urban Park",
+    "single_match": {
+      "factual_category_id": "122",
+      "factual_category_label": "Landmarks > Parks > Urban Parks",
+      "is_exact": true
+    }
+  },
+  "16040": {
+    "integrated_label": "Landmarks and Outdoors > Pedestrian Plaza",
+    "single_match": {
+      "factual_category_id": "107",
+      "factual_category_label": "Landmarks",
+      "is_exact": false
+    }
+  },
+  "16041": {
+    "integrated_label": "Landmarks and Outdoors > Plaza",
+    "single_match": {
+      "factual_category_id": "107",
+      "factual_category_label": "Landmarks",
+      "is_exact": false
+    }
+  },
+  "16042": {
+    "integrated_label": "Landmarks and Outdoors > Reservoir",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16043": {
+    "integrated_label": "Landmarks and Outdoors > River",
+    "single_match": {
+      "factual_category_id": "117",
+      "factual_category_label": "Landmarks > Natural > Rivers",
+      "is_exact": true
+    }
+  },
+  "16044": {
+    "integrated_label": "Landmarks and Outdoors > Rock Climbing Spot",
+    "single_match": {
+      "factual_category_id": "392",
+      "factual_category_label": "Sports and Recreation > Outdoors > Rock Climbing",
+      "is_exact": false
+    }
+  },
+  "16045": {
+    "integrated_label": "Landmarks and Outdoors > Roof Deck",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16046": {
+    "integrated_label": "Landmarks and Outdoors > Scenic Lookout",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16047": {
+    "integrated_label": "Landmarks and Outdoors > Sculpture Garden",
+    "single_match": {
+      "factual_category_id": "109",
+      "factual_category_label": "Landmarks > Gardens",
+      "is_exact": false
+    }
+  },
+  "16048": {
+    "integrated_label": "Landmarks and Outdoors > Stable",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16049": {
+    "integrated_label": "Landmarks and Outdoors > Surf Spot",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16050": {
+    "integrated_label": "Landmarks and Outdoors > Tunnel",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "16051": {
+    "integrated_label": "Landmarks and Outdoors > Volcano",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16052": {
+    "integrated_label": "Landmarks and Outdoors > Waterfall",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16053": {
+    "integrated_label": "Landmarks and Outdoors > Waterfront",
+    "single_match": {
+      "factual_category_id": "112",
+      "factual_category_label": "Landmarks > Natural",
+      "is_exact": false
+    }
+  },
+  "16054": {
+    "integrated_label": "Landmarks and Outdoors > Windmill",
+    "single_match": {
+      "factual_category_id": "108",
+      "factual_category_label": "Landmarks > Buildings and Structures",
+      "is_exact": false
+    }
+  },
+  "17000": {
+    "integrated_label": "Retail",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": true
+    }
+  },
+  "17001": {
+    "integrated_label": "Retail > Adult Store",
+    "single_match": {
+      "factual_category_id": "124",
+      "factual_category_label": "Retail > Adult",
+      "is_exact": true
+    }
+  },
+  "17002": {
+    "integrated_label": "Retail > Antique Store",
+    "single_match": {
+      "factual_category_id": "125",
+      "factual_category_label": "Retail > Antiques",
+      "is_exact": true
+    }
+  },
+  "17003": {
+    "integrated_label": "Retail > Arts and Crafts Store",
+    "single_match": {
+      "factual_category_id": "126",
+      "factual_category_label": "Retail > Arts and Crafts",
+      "is_exact": true
+    }
+  },
+  "17004": {
+    "integrated_label": "Retail > Auction House",
+    "single_match": {
+      "factual_category_id": "127",
+      "factual_category_label": "Retail > Auctions",
+      "is_exact": true
+    }
+  },
+  "17005": {
+    "integrated_label": "Retail > Automotive Retail",
+    "single_match": {
+      "factual_category_id": "2",
+      "factual_category_label": "Automotive",
+      "is_exact": false
+    }
+  },
+  "17006": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership",
+    "single_match": {
+      "factual_category_id": "4",
+      "factual_category_label": "Automotive > Car Dealers and Leasing",
+      "is_exact": true
+    }
+  },
+  "17007": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > Classic and Antique Car Dealership",
+    "single_match": {
+      "factual_category_id": "8",
+      "factual_category_label": "Automotive > Classic and Antique Car",
+      "is_exact": true
+    }
+  },
+  "17008": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > New Car Dealership",
+    "single_match": {
+      "factual_category_id": "4",
+      "factual_category_label": "Automotive > Car Dealers and Leasing",
+      "is_exact": false
+    }
+  },
+  "17009": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > RV and Motorhome Dealership",
+    "single_match": {
+      "factual_category_id": "17",
+      "factual_category_label": "Automotive > RVs and Motor Homes",
+      "is_exact": true
+    }
+  },
+  "17010": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > Used Car Dealership",
+    "single_match": {
+      "factual_category_id": "5",
+      "factual_category_label": "Automotive > Car Dealers and Leasing > Used Cars",
+      "is_exact": true
+    }
+  },
+  "17011": {
+    "integrated_label": "Retail > Automotive Retail > Car Parts and Accessories",
+    "single_match": {
+      "factual_category_id": "6",
+      "factual_category_label": "Automotive > Car Parts and Accessories",
+      "is_exact": true
+    }
+  },
+  "17012": {
+    "integrated_label": "Retail > Automotive Retail > Motorcycle Dealership",
+    "single_match": {
+      "factual_category_id": "16",
+      "factual_category_label": "Automotive > Motorcycles, Mopeds and Scooters > Sales",
+      "is_exact": true
+    }
+  },
+  "17013": {
+    "integrated_label": "Retail > Automotive Retail > Motorsports Store",
+    "single_match": {
+      "factual_category_id": "14",
+      "factual_category_label": "Automotive > Motorcycles, Mopeds and Scooters",
+      "is_exact": true
+    }
+  },
+  "17014": {
+    "integrated_label": "Retail > Baby Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17015": {
+    "integrated_label": "Retail > Betting Shop",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17016": {
+    "integrated_label": "Retail > Big Box Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17017": {
+    "integrated_label": "Retail > Board Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17018": {
+    "integrated_label": "Retail > Bookstore",
+    "single_match": {
+      "factual_category_id": "130",
+      "factual_category_label": "Retail > Bookstores",
+      "is_exact": true
+    }
+  },
+  "17019": {
+    "integrated_label": "Retail > Bookstore > Used Bookstore",
+    "single_match": {
+      "factual_category_id": "130",
+      "factual_category_label": "Retail > Bookstores",
+      "is_exact": false
+    }
+  },
+  "17020": {
+    "integrated_label": "Retail > Boutique",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17021": {
+    "integrated_label": "Retail > Cannabis Store",
+    "single_match": {
+      "factual_category_id": "484",
+      "factual_category_label": "Retail > Cannabis Stores",
+      "is_exact": true
+    }
+  },
+  "17022": {
+    "integrated_label": "Retail > Comic Book Store",
+    "single_match": {
+      "factual_category_id": "480",
+      "factual_category_label": "Retail > Comic Book Stores",
+      "is_exact": true
+    }
+  },
+  "17023": {
+    "integrated_label": "Retail > Computers and Electronics Retail",
+    "single_match": {
+      "factual_category_id": "133",
+      "factual_category_label": "Retail > Computers and Electronics",
+      "is_exact": true
+    }
+  },
+  "17024": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Camera Store",
+    "single_match": {
+      "factual_category_id": "134",
+      "factual_category_label": "Retail > Computers and Electronics > Cameras",
+      "is_exact": true
+    }
+  },
+  "17025": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Electronics Store",
+    "single_match": {
+      "factual_category_id": "133",
+      "factual_category_label": "Retail > Computers and Electronics",
+      "is_exact": false
+    }
+  },
+  "17026": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Mobile Phone Store",
+    "single_match": {
+      "factual_category_id": "135",
+      "factual_category_label": "Retail > Computers and Electronics > Mobile Phones",
+      "is_exact": true
+    }
+  },
+  "17027": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Video Games Store",
+    "single_match": {
+      "factual_category_id": "136",
+      "factual_category_label": "Retail > Computers and Electronics > Video Games",
+      "is_exact": true
+    }
+  },
+  "17028": {
+    "integrated_label": "Retail > Construction Supplies Store",
+    "single_match": {
+      "factual_category_id": "137",
+      "factual_category_label": "Retail > Construction Supplies",
+      "is_exact": true
+    }
+  },
+  "17029": {
+    "integrated_label": "Retail > Convenience Store",
+    "single_match": {
+      "factual_category_id": "138",
+      "factual_category_label": "Retail > Convenience Stores",
+      "is_exact": true
+    }
+  },
+  "17030": {
+    "integrated_label": "Retail > Cosmetics Store",
+    "single_match": {
+      "factual_category_id": "128",
+      "factual_category_label": "Retail > Beauty Products",
+      "is_exact": true
+    }
+  },
+  "17031": {
+    "integrated_label": "Retail > Costume Store",
+    "single_match": {
+      "factual_category_id": "139",
+      "factual_category_label": "Retail > Costumes",
+      "is_exact": true
+    }
+  },
+  "17032": {
+    "integrated_label": "Retail > Dance Store",
+    "single_match": {
+      "factual_category_id": "140",
+      "factual_category_label": "Retail > Dance and Music",
+      "is_exact": true
+    }
+  },
+  "17033": {
+    "integrated_label": "Retail > Department Store",
+    "single_match": {
+      "factual_category_id": "141",
+      "factual_category_label": "Retail > Department Stores",
+      "is_exact": true
+    }
+  },
+  "17034": {
+    "integrated_label": "Retail > Discount Store",
+    "single_match": {
+      "factual_category_id": "442",
+      "factual_category_label": "Retail > Discount Stores",
+      "is_exact": true
+    }
+  },
+  "17035": {
+    "integrated_label": "Retail > Drugstore",
+    "single_match": {
+      "factual_category_id": "80",
+      "factual_category_label": "Healthcare > Pharmacies",
+      "is_exact": false
+    }
+  },
+  "17036": {
+    "integrated_label": "Retail > Duty-free Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17037": {
+    "integrated_label": "Retail > Eyecare Store",
+    "single_match": {
+      "factual_category_id": "159",
+      "factual_category_label": "Retail > Glasses",
+      "is_exact": true
+    }
+  },
+  "17038": {
+    "integrated_label": "Retail > Fabric / Textiles Store",
+    "single_match": {
+      "factual_category_id": "190",
+      "factual_category_label": "Businesses and Services > Textiles",
+      "is_exact": true
+    }
+  },
+  "17039": {
+    "integrated_label": "Retail > Fashion Retail",
+    "single_match": {
+      "factual_category_id": "142",
+      "factual_category_label": "Retail > Fashion",
+      "is_exact": true
+    }
+  },
+  "17040": {
+    "integrated_label": "Retail > Fashion Retail > Batik Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17041": {
+    "integrated_label": "Retail > Fashion Retail > Bridal Store",
+    "single_match": {
+      "factual_category_id": "176",
+      "factual_category_label": "Retail > Wedding and Bridal",
+      "is_exact": true
+    }
+  },
+  "17042": {
+    "integrated_label": "Retail > Fashion Retail > Children's Clothing Store",
+    "single_match": {
+      "factual_category_id": "132",
+      "factual_category_label": "Retail > Children",
+      "is_exact": true
+    }
+  },
+  "17043": {
+    "integrated_label": "Retail > Fashion Retail > Clothing Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17044": {
+    "integrated_label": "Retail > Fashion Retail > Fashion Accessories Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17045": {
+    "integrated_label": "Retail > Fashion Retail > Jewelry Store",
+    "single_match": {
+      "factual_category_id": "144",
+      "factual_category_label": "Retail > Fashion > Jewelry and Watches",
+      "is_exact": false
+    }
+  },
+  "17046": {
+    "integrated_label": "Retail > Fashion Retail > Lingerie Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17047": {
+    "integrated_label": "Retail > Fashion Retail > Men's Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17048": {
+    "integrated_label": "Retail > Fashion Retail > Shoe Store",
+    "single_match": {
+      "factual_category_id": "145",
+      "factual_category_label": "Retail > Fashion > Shoes",
+      "is_exact": true
+    }
+  },
+  "17049": {
+    "integrated_label": "Retail > Fashion Retail > Sunglasses Store",
+    "single_match": {
+      "factual_category_id": "159",
+      "factual_category_label": "Retail > Glasses",
+      "is_exact": false
+    }
+  },
+  "17050": {
+    "integrated_label": "Retail > Fashion Retail > Swimwear Store",
+    "single_match": {
+      "factual_category_id": "146",
+      "factual_category_label": "Retail > Fashion > Swimwear",
+      "is_exact": true
+    }
+  },
+  "17051": {
+    "integrated_label": "Retail > Fashion Retail > Watch Store",
+    "single_match": {
+      "factual_category_id": "144",
+      "factual_category_label": "Retail > Fashion > Jewelry and Watches",
+      "is_exact": false
+    }
+  },
+  "17052": {
+    "integrated_label": "Retail > Fashion Retail > Women's Store",
+    "single_match": {
+      "factual_category_id": "143",
+      "factual_category_label": "Retail > Fashion > Clothing and Accessories",
+      "is_exact": false
+    }
+  },
+  "17053": {
+    "integrated_label": "Retail > Fireworks Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17054": {
+    "integrated_label": "Retail > Flea Market",
+    "single_match": {
+      "factual_category_id": "147",
+      "factual_category_label": "Retail > Flea Markets",
+      "is_exact": true
+    }
+  },
+  "17055": {
+    "integrated_label": "Retail > Floating Market",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17056": {
+    "integrated_label": "Retail > Flower Store",
+    "single_match": {
+      "factual_category_id": "148",
+      "factual_category_label": "Retail > Florists",
+      "is_exact": true
+    }
+  },
+  "17057": {
+    "integrated_label": "Retail > Food and Beverage Retail",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": true
+    }
+  },
+  "17058": {
+    "integrated_label": "Retail > Food and Beverage Retail > Beer Store",
+    "single_match": {
+      "factual_category_id": "150",
+      "factual_category_label": "Retail > Food and Beverage > Beer, Wine and Spirits",
+      "is_exact": false
+    }
+  },
+  "17059": {
+    "integrated_label": "Retail > Food and Beverage Retail > Butcher",
+    "single_match": {
+      "factual_category_id": "443",
+      "factual_category_label": "Retail > Food and Beverage > Meat and Seafood",
+      "is_exact": false
+    }
+  },
+  "17060": {
+    "integrated_label": "Retail > Food and Beverage Retail > Candy Store",
+    "single_match": {
+      "factual_category_id": "151",
+      "factual_category_label": "Retail > Food and Beverage > Candy Stores",
+      "is_exact": true
+    }
+  },
+  "17061": {
+    "integrated_label": "Retail > Food and Beverage Retail > Cheese Store",
+    "single_match": {
+      "factual_category_id": "152",
+      "factual_category_label": "Retail > Food and Beverage > Cheese",
+      "is_exact": true
+    }
+  },
+  "17062": {
+    "integrated_label": "Retail > Food and Beverage Retail > Chocolate Store",
+    "single_match": {
+      "factual_category_id": "153",
+      "factual_category_label": "Retail > Food and Beverage > Chocolate",
+      "is_exact": true
+    }
+  },
+  "17063": {
+    "integrated_label": "Retail > Food and Beverage Retail > Coffee Roaster",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17064": {
+    "integrated_label": "Retail > Food and Beverage Retail > Dairy Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17065": {
+    "integrated_label": "Retail > Food and Beverage Retail > Farmers' Market",
+    "single_match": {
+      "factual_category_id": "154",
+      "factual_category_label": "Retail > Food and Beverage > Farmers' Markets",
+      "is_exact": true
+    }
+  },
+  "17066": {
+    "integrated_label": "Retail > Food and Beverage Retail > Fish Market",
+    "single_match": {
+      "factual_category_id": "443",
+      "factual_category_label": "Retail > Food and Beverage > Meat and Seafood",
+      "is_exact": false
+    }
+  },
+  "17067": {
+    "integrated_label": "Retail > Food and Beverage Retail > Fruit and Vegetable Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17068": {
+    "integrated_label": "Retail > Food and Beverage Retail > Gourmet Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17069": {
+    "integrated_label": "Retail > Food and Beverage Retail > Grocery Store / Supermarket",
+    "single_match": {
+      "factual_category_id": "171",
+      "factual_category_label": "Retail > Supermarkets and Groceries",
+      "is_exact": true
+    }
+  },
+  "17070": {
+    "integrated_label": "Retail > Food and Beverage Retail > Grocery Store / Supermarket > Organic Grocery",
+    "single_match": {
+      "factual_category_id": "171",
+      "factual_category_label": "Retail > Supermarkets and Groceries",
+      "is_exact": false
+    }
+  },
+  "17071": {
+    "integrated_label": "Retail > Food and Beverage Retail > Health Food Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17072": {
+    "integrated_label": "Retail > Food and Beverage Retail > Herbs and Spices Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17073": {
+    "integrated_label": "Retail > Food and Beverage Retail > Imported Food Store",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17074": {
+    "integrated_label": "Retail > Food and Beverage Retail > Kosher Store",
+    "single_match": {
+      "factual_category_id": "156",
+      "factual_category_label": "Retail > Food and Beverage > Kosher",
+      "is_exact": true
+    }
+  },
+  "17075": {
+    "integrated_label": "Retail > Food and Beverage Retail > Kuruyemişçi Shop",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17076": {
+    "integrated_label": "Retail > Food and Beverage Retail > Liquor Store",
+    "single_match": {
+      "factual_category_id": "150",
+      "factual_category_label": "Retail > Food and Beverage > Beer, Wine and Spirits",
+      "is_exact": false
+    }
+  },
+  "17077": {
+    "integrated_label": "Retail > Food and Beverage Retail > Meat and Seafood Store",
+    "single_match": {
+      "factual_category_id": "443",
+      "factual_category_label": "Retail > Food and Beverage > Meat and Seafood",
+      "is_exact": true
+    }
+  },
+  "17078": {
+    "integrated_label": "Retail > Food and Beverage Retail > Sausage Store",
+    "single_match": {
+      "factual_category_id": "443",
+      "factual_category_label": "Retail > Food and Beverage > Meat and Seafood",
+      "is_exact": false
+    }
+  },
+  "17079": {
+    "integrated_label": "Retail > Food and Beverage Retail > Turşucu Shop",
+    "single_match": {
+      "factual_category_id": "149",
+      "factual_category_label": "Retail > Food and Beverage",
+      "is_exact": false
+    }
+  },
+  "17080": {
+    "integrated_label": "Retail > Food and Beverage Retail > Wine Store",
+    "single_match": {
+      "factual_category_id": "150",
+      "factual_category_label": "Retail > Food and Beverage > Beer, Wine and Spirits",
+      "is_exact": false
+    }
+  },
+  "17081": {
+    "integrated_label": "Retail > Framing Store",
+    "single_match": {
+      "factual_category_id": "168",
+      "factual_category_label": "Retail > Photos and Frames",
+      "is_exact": true
+    }
+  },
+  "17082": {
+    "integrated_label": "Retail > Furniture and Home Store",
+    "single_match": {
+      "factual_category_id": "157",
+      "factual_category_label": "Retail > Furniture and Decor",
+      "is_exact": true
+    }
+  },
+  "17083": {
+    "integrated_label": "Retail > Furniture and Home Store > Carpet Store",
+    "single_match": {
+      "factual_category_id": "157",
+      "factual_category_label": "Retail > Furniture and Decor",
+      "is_exact": false
+    }
+  },
+  "17084": {
+    "integrated_label": "Retail > Furniture and Home Store > Home Appliance Store",
+    "single_match": {
+      "factual_category_id": "248",
+      "factual_category_label": "Retail > Home Appliances",
+      "is_exact": true
+    }
+  },
+  "17085": {
+    "integrated_label": "Retail > Furniture and Home Store > Housewares Store",
+    "single_match": {
+      "factual_category_id": "250",
+      "factual_category_label": "Retail > Housewares",
+      "is_exact": true
+    }
+  },
+  "17086": {
+    "integrated_label": "Retail > Furniture and Home Store > Kitchen Supply Store",
+    "single_match": {
+      "factual_category_id": "157",
+      "factual_category_label": "Retail > Furniture and Decor",
+      "is_exact": false
+    }
+  },
+  "17087": {
+    "integrated_label": "Retail > Furniture and Home Store > Lighting Store",
+    "single_match": {
+      "factual_category_id": "157",
+      "factual_category_label": "Retail > Furniture and Decor",
+      "is_exact": false
+    }
+  },
+  "17088": {
+    "integrated_label": "Retail > Furniture and Home Store > Mattress Store",
+    "single_match": {
+      "factual_category_id": "157",
+      "factual_category_label": "Retail > Furniture and Decor",
+      "is_exact": false
+    }
+  },
+  "17089": {
+    "integrated_label": "Retail > Gift Store",
+    "single_match": {
+      "factual_category_id": "158",
+      "factual_category_label": "Retail > Gift and Novelty",
+      "is_exact": true
+    }
+  },
+  "17090": {
+    "integrated_label": "Retail > Hardware Store",
+    "single_match": {
+      "factual_category_id": "468",
+      "factual_category_label": "Retail > Hardware Stores",
+      "is_exact": true
+    }
+  },
+  "17091": {
+    "integrated_label": "Retail > Hobby Store",
+    "single_match": {
+      "factual_category_id": "160",
+      "factual_category_label": "Retail > Hobby and Collectibles",
+      "is_exact": true
+    }
+  },
+  "17092": {
+    "integrated_label": "Retail > Knitting Store",
+    "single_match": {
+      "factual_category_id": "126",
+      "factual_category_label": "Retail > Arts and Crafts",
+      "is_exact": false
+    }
+  },
+  "17093": {
+    "integrated_label": "Retail > Leather Goods Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17094": {
+    "integrated_label": "Retail > Luggage Store",
+    "single_match": {
+      "factual_category_id": "161",
+      "factual_category_label": "Retail > Luggage",
+      "is_exact": true
+    }
+  },
+  "17095": {
+    "integrated_label": "Retail > Medical Supply Store",
+    "single_match": {
+      "factual_category_id": "75",
+      "factual_category_label": "Healthcare > Medical Supplies and Labs",
+      "is_exact": false
+    }
+  },
+  "17096": {
+    "integrated_label": "Retail > Miscellaneous Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17097": {
+    "integrated_label": "Retail > Mobility Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17098": {
+    "integrated_label": "Retail > Music Store",
+    "single_match": {
+      "factual_category_id": "162",
+      "factual_category_label": "Retail > Music, Video and DVD",
+      "is_exact": false
+    }
+  },
+  "17099": {
+    "integrated_label": "Retail > Newsagent",
+    "single_match": {
+      "factual_category_id": "163",
+      "factual_category_label": "Retail > Newsstands",
+      "is_exact": false
+    }
+  },
+  "17100": {
+    "integrated_label": "Retail > Newsstand",
+    "single_match": {
+      "factual_category_id": "163",
+      "factual_category_label": "Retail > Newsstands",
+      "is_exact": true
+    }
+  },
+  "17101": {
+    "integrated_label": "Retail > Garden Center",
+    "single_match": {
+      "factual_category_id": "164",
+      "factual_category_label": "Retail > Nurseries and Garden Centers",
+      "is_exact": true
+    }
+  },
+  "17102": {
+    "integrated_label": "Retail > Office Supply Store",
+    "single_match": {
+      "factual_category_id": "444",
+      "factual_category_label": "Retail > Office Supplies",
+      "is_exact": true
+    }
+  },
+  "17103": {
+    "integrated_label": "Retail > Outdoor Supply Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17104": {
+    "integrated_label": "Retail > Outlet Mall",
+    "single_match": {
+      "factual_category_id": "169",
+      "factual_category_label": "Retail > Shopping Centers and Malls",
+      "is_exact": false
+    }
+  },
+  "17105": {
+    "integrated_label": "Retail > Outlet Store",
+    "single_match": {
+      "factual_category_id": "165",
+      "factual_category_label": "Retail > Outlet",
+      "is_exact": true
+    }
+  },
+  "17106": {
+    "integrated_label": "Retail > Packaging Supply Store",
+    "single_match": {
+      "factual_category_id": "182",
+      "factual_category_label": "Businesses and Services > Packaging",
+      "is_exact": true
+    }
+  },
+  "17107": {
+    "integrated_label": "Retail > Party Supply Store",
+    "single_match": {
+      "factual_category_id": "445",
+      "factual_category_label": "Retail > Party Supplies",
+      "is_exact": true
+    }
+  },
+  "17108": {
+    "integrated_label": "Retail > Pawn Shop",
+    "single_match": {
+      "factual_category_id": "166",
+      "factual_category_label": "Retail > Pawn Shops",
+      "is_exact": true
+    }
+  },
+  "17109": {
+    "integrated_label": "Retail > Perfume Store",
+    "single_match": {
+      "factual_category_id": "142",
+      "factual_category_label": "Retail > Fashion",
+      "is_exact": false
+    }
+  },
+  "17110": {
+    "integrated_label": "Retail > Pet Supplies Store",
+    "single_match": {
+      "factual_category_id": "471",
+      "factual_category_label": "Retail > Pets > Pet Supplies",
+      "is_exact": true
+    }
+  },
+  "17111": {
+    "integrated_label": "Retail > Pop-Up Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17112": {
+    "integrated_label": "Retail > Print Store",
+    "single_match": {
+      "factual_category_id": "288",
+      "factual_category_label": "Businesses and Services > Printing, Copying and Signage",
+      "is_exact": true
+    }
+  },
+  "17113": {
+    "integrated_label": "Retail > Record Store",
+    "single_match": {
+      "factual_category_id": "169",
+      "factual_category_label": "Retail > Shopping Centers and Malls",
+      "is_exact": true
+    }
+  },
+  "17114": {
+    "integrated_label": "Retail > Shopping Mall",
+    "single_match": {
+      "factual_category_id": "169",
+      "factual_category_label": "Retail > Shopping Centers and Malls",
+      "is_exact": false
+    }
+  },
+  "17115": {
+    "integrated_label": "Retail > Shopping Plaza",
+    "single_match": {
+      "factual_category_id": "169",
+      "factual_category_label": "Retail > Shopping Centers and Malls",
+      "is_exact": false
+    }
+  },
+  "17116": {
+    "integrated_label": "Retail > Souvenir Store",
+    "single_match": {
+      "factual_category_id": "158",
+      "factual_category_label": "Retail > Gift and Novelty",
+      "is_exact": false
+    }
+  },
+  "17117": {
+    "integrated_label": "Retail > Sporting Goods Retail",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17118": {
+    "integrated_label": "Retail > Sporting Goods Retail > Baseball Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17119": {
+    "integrated_label": "Retail > Sporting Goods Retail > Bicycle Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17120": {
+    "integrated_label": "Retail > Sporting Goods Retail > Dive Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17121": {
+    "integrated_label": "Retail > Sporting Goods Retail > Fishing Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17122": {
+    "integrated_label": "Retail > Sporting Goods Retail > Golf Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17123": {
+    "integrated_label": "Retail > Sporting Goods Retail > Gun Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17124": {
+    "integrated_label": "Retail > Sporting Goods Retail > Hunting Supply Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17125": {
+    "integrated_label": "Retail > Sporting Goods Retail > Running Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17126": {
+    "integrated_label": "Retail > Sporting Goods Retail > Skate Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17127": {
+    "integrated_label": "Retail > Sporting Goods Retail > Ski Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17128": {
+    "integrated_label": "Retail > Sporting Goods Retail > Soccer Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17129": {
+    "integrated_label": "Retail > Sporting Goods Retail > Surf Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17130": {
+    "integrated_label": "Retail > Sporting Goods Retail > Tennis Store",
+    "single_match": {
+      "factual_category_id": "123",
+      "factual_category_label": "Retail",
+      "is_exact": false
+    }
+  },
+  "17131": {
+    "integrated_label": "Retail > Stationery Store",
+    "single_match": {
+      "factual_category_id": "131",
+      "factual_category_label": "Retail > Cards and Stationery",
+      "is_exact": true
+    }
+  },
+  "17132": {
+    "integrated_label": "Retail > Supplement Store",
+    "single_match": {
+      "factual_category_id": "155",
+      "factual_category_label": "Retail > Food and Beverage > Health and Diet Food",
+      "is_exact": false
+    }
+  },
+  "17133": {
+    "integrated_label": "Retail > Swimming Pool Supply Store",
+    "single_match": {
+      "factual_category_id": "263",
+      "factual_category_label": "Businesses and Services > Home Improvement > Swimming Pool Maintenance and Services",
+      "is_exact": false
+    }
+  },
+  "17134": {
+    "integrated_label": "Retail > Tobacco Store",
+    "single_match": {
+      "factual_category_id": "172",
+      "factual_category_label": "Retail > Tobacco",
+      "is_exact": true
+    }
+  },
+  "17135": {
+    "integrated_label": "Retail > Toy / Game Store",
+    "single_match": {
+      "factual_category_id": "173",
+      "factual_category_label": "Retail > Toys",
+      "is_exact": true
+    }
+  },
+  "17136": {
+    "integrated_label": "Retail > Vaporizer Store",
+    "single_match": {
+      "factual_category_id": "483",
+      "factual_category_label": "Retail > Tobacco > Vaporizer Shops",
+      "is_exact": true
+    }
+  },
+  "17137": {
+    "integrated_label": "Retail > Video Store",
+    "single_match": {
+      "factual_category_id": "162",
+      "factual_category_label": "Retail > Music, Video and DVD",
+      "is_exact": false
+    }
+  },
+  "17138": {
+    "integrated_label": "Retail > Vintage and Thrift Store",
+    "single_match": {
+      "factual_category_id": "174",
+      "factual_category_label": "Retail > Vintage and Thrift",
+      "is_exact": true
+    }
+  },
+  "17139": {
+    "integrated_label": "Retail > Warehouse / Wholesale Store",
+    "single_match": {
+      "factual_category_id": "175",
+      "factual_category_label": "Retail > Warehouses and Wholesale Stores",
+      "is_exact": true
+    }
+  },
+  "18000": {
+    "integrated_label": "Sports and Recreation",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": true
+    }
+  },
+  "18001": {
+    "integrated_label": "Sports and Recreation > Athletic Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": true
+    }
+  },
+  "18002": {
+    "integrated_label": "Sports and Recreation > Baseball",
+    "single_match": {
+      "factual_category_id": "374",
+      "factual_category_label": "Sports and Recreation > Baseball",
+      "is_exact": true
+    }
+  },
+  "18003": {
+    "integrated_label": "Sports and Recreation > Baseball > Baseball Club",
+    "single_match": {
+      "factual_category_id": "374",
+      "factual_category_label": "Sports and Recreation > Baseball",
+      "is_exact": false
+    }
+  },
+  "18004": {
+    "integrated_label": "Sports and Recreation > Baseball > Baseball Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18005": {
+    "integrated_label": "Sports and Recreation > Baseball > Batting Range",
+    "single_match": {
+      "factual_category_id": "375",
+      "factual_category_label": "Sports and Recreation > Baseball > Batting Ranges",
+      "is_exact": true
+    }
+  },
+  "18006": {
+    "integrated_label": "Sports and Recreation > Basketball",
+    "single_match": {
+      "factual_category_id": "376",
+      "factual_category_label": "Sports and Recreation > Basketball",
+      "is_exact": true
+    }
+  },
+  "18007": {
+    "integrated_label": "Sports and Recreation > Basketball > Basketball Club",
+    "single_match": {
+      "factual_category_id": "376",
+      "factual_category_label": "Sports and Recreation > Basketball",
+      "is_exact": false
+    }
+  },
+  "18008": {
+    "integrated_label": "Sports and Recreation > Basketball > Basketball Court",
+    "single_match": {
+      "factual_category_id": "376",
+      "factual_category_label": "Sports and Recreation > Basketball",
+      "is_exact": false
+    }
+  },
+  "18009": {
+    "integrated_label": "Sports and Recreation > Bowling Green",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18010": {
+    "integrated_label": "Sports and Recreation > Cricket Ground",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18011": {
+    "integrated_label": "Sports and Recreation > Curling Ice",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18012": {
+    "integrated_label": "Sports and Recreation > Equestrian Facility",
+    "single_match": {
+      "factual_category_id": "380",
+      "factual_category_label": "Sports and Recreation > Equestrian",
+      "is_exact": true
+    }
+  },
+  "18013": {
+    "integrated_label": "Sports and Recreation > Football",
+    "single_match": {
+      "factual_category_id": "381",
+      "factual_category_label": "Sports and Recreation > Football",
+      "is_exact": true
+    }
+  },
+  "18014": {
+    "integrated_label": "Sports and Recreation > Football > Football Club",
+    "single_match": {
+      "factual_category_id": "381",
+      "factual_category_label": "Sports and Recreation > Football",
+      "is_exact": false
+    }
+  },
+  "18015": {
+    "integrated_label": "Sports and Recreation > Football > Football Field",
+    "single_match": {
+      "factual_category_id": "381",
+      "factual_category_label": "Sports and Recreation > Football",
+      "is_exact": false
+    }
+  },
+  "18016": {
+    "integrated_label": "Sports and Recreation > Golf",
+    "single_match": {
+      "factual_category_id": "382",
+      "factual_category_label": "Sports and Recreation > Golf",
+      "is_exact": true
+    }
+  },
+  "18017": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Club",
+    "single_match": {
+      "factual_category_id": "382",
+      "factual_category_label": "Sports and Recreation > Golf",
+      "is_exact": false
+    }
+  },
+  "18018": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Course",
+    "single_match": {
+      "factual_category_id": "451",
+      "factual_category_label": "Sports and Recreation > Golf > Golf Courses",
+      "is_exact": true
+    }
+  },
+  "18019": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Driving Range",
+    "single_match": {
+      "factual_category_id": "382",
+      "factual_category_label": "Sports and Recreation > Golf",
+      "is_exact": false
+    }
+  },
+  "18020": {
+    "integrated_label": "Sports and Recreation > Gun Range",
+    "single_match": {
+      "factual_category_id": "383",
+      "factual_category_label": "Sports and Recreation > Gun Ranges",
+      "is_exact": true
+    }
+  },
+  "18021": {
+    "integrated_label": "Sports and Recreation > Gym and Studio",
+    "single_match": {
+      "factual_category_id": "385",
+      "factual_category_label": "Sports and Recreation > Gyms and Fitness Centers",
+      "is_exact": true
+    }
+  },
+  "18022": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Boxing Gym",
+    "single_match": {
+      "factual_category_id": "385",
+      "factual_category_label": "Sports and Recreation > Gyms and Fitness Centers",
+      "is_exact": false
+    }
+  },
+  "18023": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Climbing Gym",
+    "single_match": {
+      "factual_category_id": "392",
+      "factual_category_label": "Sports and Recreation > Outdoors > Rock Climbing",
+      "is_exact": false
+    }
+  },
+  "18024": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Cycle Studio",
+    "single_match": {
+      "factual_category_id": "385",
+      "factual_category_label": "Sports and Recreation > Gyms and Fitness Centers",
+      "is_exact": false
+    }
+  },
+  "18025": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Dance Studio",
+    "single_match": {
+      "factual_category_id": "379",
+      "factual_category_label": "Sports and Recreation > Dance",
+      "is_exact": false
+    }
+  },
+  "18026": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Outdoor Gym",
+    "single_match": {
+      "factual_category_id": "385",
+      "factual_category_label": "Sports and Recreation > Gyms and Fitness Centers",
+      "is_exact": false
+    }
+  },
+  "18027": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Pilates Studio",
+    "single_match": {
+      "factual_category_id": "414",
+      "factual_category_label": "Sports and Recreation > Yoga and Pilates",
+      "is_exact": false
+    }
+  },
+  "18028": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Yoga Studio",
+    "single_match": {
+      "factual_category_id": "414",
+      "factual_category_label": "Sports and Recreation > Yoga and Pilates",
+      "is_exact": false
+    }
+  },
+  "18029": {
+    "integrated_label": "Sports and Recreation > Gymnastics",
+    "single_match": {
+      "factual_category_id": "384",
+      "factual_category_label": "Sports and Recreation > Gymnastics",
+      "is_exact": true
+    }
+  },
+  "18030": {
+    "integrated_label": "Sports and Recreation > Gymnastics > Gymnastics Center",
+    "single_match": {
+      "factual_category_id": "384",
+      "factual_category_label": "Sports and Recreation > Gymnastics",
+      "is_exact": false
+    }
+  },
+  "18031": {
+    "integrated_label": "Sports and Recreation > Hockey",
+    "single_match": {
+      "factual_category_id": "386",
+      "factual_category_label": "Sports and Recreation > Hockey",
+      "is_exact": true
+    }
+  },
+  "18032": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Club",
+    "single_match": {
+      "factual_category_id": "386",
+      "factual_category_label": "Sports and Recreation > Hockey",
+      "is_exact": false
+    }
+  },
+  "18033": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18034": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Rink",
+    "single_match": {
+      "factual_category_id": "386",
+      "factual_category_label": "Sports and Recreation > Hockey",
+      "is_exact": false
+    }
+  },
+  "18035": {
+    "integrated_label": "Sports and Recreation > Indoor Play Area",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18036": {
+    "integrated_label": "Sports and Recreation > Martial Arts Dojo",
+    "single_match": {
+      "factual_category_id": "377",
+      "factual_category_label": "Sports and Recreation > Combat Sports",
+      "is_exact": true
+    }
+  },
+  "18037": {
+    "integrated_label": "Sports and Recreation > Paintball Field",
+    "single_match": {
+      "factual_category_id": "394",
+      "factual_category_label": "Sports and Recreation > Paintball",
+      "is_exact": true
+    }
+  },
+  "18038": {
+    "integrated_label": "Sports and Recreation > Personal Trainer",
+    "single_match": {
+      "factual_category_id": "395",
+      "factual_category_label": "Sports and Recreation > Personal Trainers",
+      "is_exact": true
+    }
+  },
+  "18039": {
+    "integrated_label": "Sports and Recreation > Race Track",
+    "single_match": {
+      "factual_category_id": "396",
+      "factual_category_label": "Sports and Recreation > Race Tracks",
+      "is_exact": true
+    }
+  },
+  "18040": {
+    "integrated_label": "Sports and Recreation > Racquet Sports",
+    "single_match": {
+      "factual_category_id": "397",
+      "factual_category_label": "Sports and Recreation > Racquet Sports",
+      "is_exact": true
+    }
+  },
+  "18041": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Badminton Court",
+    "single_match": {
+      "factual_category_id": "397",
+      "factual_category_label": "Sports and Recreation > Racquet Sports",
+      "is_exact": false
+    }
+  },
+  "18042": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Racquet Sport Club",
+    "single_match": {
+      "factual_category_id": "397",
+      "factual_category_label": "Sports and Recreation > Racquet Sports",
+      "is_exact": false
+    }
+  },
+  "18043": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Racquetball Club",
+    "single_match": {
+      "factual_category_id": "398",
+      "factual_category_label": "Sports and Recreation > Racquet Sports > Racquetball",
+      "is_exact": true
+    }
+  },
+  "18044": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Squash Court",
+    "single_match": {
+      "factual_category_id": "397",
+      "factual_category_label": "Sports and Recreation > Racquet Sports",
+      "is_exact": false
+    }
+  },
+  "18045": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis",
+    "single_match": {
+      "factual_category_id": "399",
+      "factual_category_label": "Sports and Recreation > Racquet Sports > Tennis",
+      "is_exact": true
+    }
+  },
+  "18046": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis > Tennis Club",
+    "single_match": {
+      "factual_category_id": "399",
+      "factual_category_label": "Sports and Recreation > Racquet Sports > Tennis",
+      "is_exact": false
+    }
+  },
+  "18047": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis > Tennis Court",
+    "single_match": {
+      "factual_category_id": "399",
+      "factual_category_label": "Sports and Recreation > Racquet Sports > Tennis",
+      "is_exact": false
+    }
+  },
+  "18048": {
+    "integrated_label": "Sports and Recreation > Recreation Center",
+    "single_match": {
+      "factual_category_id": "400",
+      "factual_category_label": "Sports and Recreation > Recreation Centers",
+      "is_exact": true
+    }
+  },
+  "18049": {
+    "integrated_label": "Sports and Recreation > Rugby",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18050": {
+    "integrated_label": "Sports and Recreation > Rugby > Rugby Pitch",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18051": {
+    "integrated_label": "Sports and Recreation > Running and Track",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18052": {
+    "integrated_label": "Sports and Recreation > Running and Track > Running Club",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18053": {
+    "integrated_label": "Sports and Recreation > Running and Track > Track",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18054": {
+    "integrated_label": "Sports and Recreation > Skating",
+    "single_match": {
+      "factual_category_id": "402",
+      "factual_category_label": "Sports and Recreation > Skating",
+      "is_exact": true
+    }
+  },
+  "18055": {
+    "integrated_label": "Sports and Recreation > Skating > Skate Park",
+    "single_match": {
+      "factual_category_id": "402",
+      "factual_category_label": "Sports and Recreation > Skating",
+      "is_exact": false
+    }
+  },
+  "18056": {
+    "integrated_label": "Sports and Recreation > Skating > Skating Rink",
+    "single_match": {
+      "factual_category_id": "402",
+      "factual_category_label": "Sports and Recreation > Skating",
+      "is_exact": false
+    }
+  },
+  "18057": {
+    "integrated_label": "Sports and Recreation > Skydiving Center",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18058": {
+    "integrated_label": "Sports and Recreation > Snow Sports",
+    "single_match": {
+      "factual_category_id": "403",
+      "factual_category_label": "Sports and Recreation > Snow Sports",
+      "is_exact": true
+    }
+  },
+  "18059": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Chalet",
+    "single_match": {
+      "factual_category_id": "403",
+      "factual_category_label": "Sports and Recreation > Snow Sports",
+      "is_exact": false
+    }
+  },
+  "18060": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Lodge",
+    "single_match": {
+      "factual_category_id": "403",
+      "factual_category_label": "Sports and Recreation > Snow Sports",
+      "is_exact": false
+    }
+  },
+  "18061": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Resorts and Areas",
+    "single_match": {
+      "factual_category_id": "403",
+      "factual_category_label": "Sports and Recreation > Snow Sports",
+      "is_exact": false
+    }
+  },
+  "18062": {
+    "integrated_label": "Sports and Recreation > Soccer",
+    "single_match": {
+      "factual_category_id": "404",
+      "factual_category_label": "Sports and Recreation > Soccer",
+      "is_exact": true
+    }
+  },
+  "18063": {
+    "integrated_label": "Sports and Recreation > Soccer > Soccer Club",
+    "single_match": {
+      "factual_category_id": "404",
+      "factual_category_label": "Sports and Recreation > Soccer",
+      "is_exact": false
+    }
+  },
+  "18064": {
+    "integrated_label": "Sports and Recreation > Soccer > Soccer Field",
+    "single_match": {
+      "factual_category_id": "373",
+      "factual_category_label": "Sports and Recreation > Athletic Fields",
+      "is_exact": false
+    }
+  },
+  "18065": {
+    "integrated_label": "Sports and Recreation > Sports Club",
+    "single_match": {
+      "factual_category_id": "405",
+      "factual_category_label": "Sports and Recreation > Sports Clubs",
+      "is_exact": true
+    }
+  },
+  "18066": {
+    "integrated_label": "Sports and Recreation > Volleyball Court",
+    "single_match": {
+      "factual_category_id": "372",
+      "factual_category_label": "Sports and Recreation",
+      "is_exact": false
+    }
+  },
+  "18067": {
+    "integrated_label": "Sports and Recreation > Water Sports",
+    "single_match": {
+      "factual_category_id": "408",
+      "factual_category_label": "Sports and Recreation > Water Sports",
+      "is_exact": true
+    }
+  },
+  "18068": {
+    "integrated_label": "Sports and Recreation > Water Sports > Canoe and Kayak Rental",
+    "single_match": {
+      "factual_category_id": "410",
+      "factual_category_label": "Sports and Recreation > Water Sports > Canoes and Kayaks",
+      "is_exact": true
+    }
+  },
+  "18069": {
+    "integrated_label": "Sports and Recreation > Water Sports > Rafting Outfitter",
+    "single_match": {
+      "factual_category_id": "411",
+      "factual_category_label": "Sports and Recreation > Water Sports > Rafting",
+      "is_exact": true
+    }
+  },
+  "18070": {
+    "integrated_label": "Sports and Recreation > Water Sports > Sailing Club",
+    "single_match": {
+      "factual_category_id": "405",
+      "factual_category_label": "Sports and Recreation > Sports Clubs",
+      "is_exact": false
+    }
+  },
+  "18071": {
+    "integrated_label": "Sports and Recreation > Water Sports > Scuba Diving Instructor",
+    "single_match": {
+      "factual_category_id": "412",
+      "factual_category_label": "Sports and Recreation > Water Sports > Scuba Diving",
+      "is_exact": true
+    }
+  },
+  "18072": {
+    "integrated_label": "Sports and Recreation > Water Sports > Surfing",
+    "single_match": {
+      "factual_category_id": "452",
+      "factual_category_label": "Sports and Recreation > Water Sports > Surfing",
+      "is_exact": true
+    }
+  },
+  "18073": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming",
+    "single_match": {
+      "factual_category_id": "413",
+      "factual_category_label": "Sports and Recreation > Water Sports > Swimming",
+      "is_exact": true
+    }
+  },
+  "18074": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swimming Club",
+    "single_match": {
+      "factual_category_id": "413",
+      "factual_category_label": "Sports and Recreation > Water Sports > Swimming",
+      "is_exact": true
+    }
+  },
+  "18075": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swimming Pool",
+    "single_match": {
+      "factual_category_id": "407",
+      "factual_category_label": "Sports and Recreation > Swimming Pools",
+      "is_exact": true
+    }
+  },
+  "18076": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swim School",
+    "single_match": {
+      "factual_category_id": "413",
+      "factual_category_label": "Sports and Recreation > Water Sports > Swimming",
+      "is_exact": false
+    }
+  },
+  "19000": {
+    "integrated_label": "Travel and Transportation",
+    "single_match": {
+      "factual_category_id": "430",
+      "factual_category_label": "Travel",
+      "is_exact": false
+    }
+  },
+  "19001": {
+    "integrated_label": "Travel and Transportation > Baggage Locker",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19002": {
+    "integrated_label": "Travel and Transportation > Bike Rental",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19003": {
+    "integrated_label": "Travel and Transportation > Boat Rental",
+    "single_match": {
+      "factual_category_id": "409",
+      "factual_category_label": "Sports and Recreation > Water Sports > Boating",
+      "is_exact": false
+    }
+  },
+  "19004": {
+    "integrated_label": "Travel and Transportation > Border Crossing",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19005": {
+    "integrated_label": "Travel and Transportation > Cruise",
+    "single_match": {
+      "factual_category_id": "431",
+      "factual_category_label": "Travel > Cruises",
+      "is_exact": true
+    }
+  },
+  "19006": {
+    "integrated_label": "Travel and Transportation > Electric Vehicle Charging Station",
+    "single_match": {
+      "factual_category_id": "479",
+      "factual_category_label": "Transportation > Fuel Stations > Electric Vehicle Charging Stations",
+      "is_exact": true
+    }
+  },
+  "19007": {
+    "integrated_label": "Travel and Transportation > Fuel Station",
+    "single_match": {
+      "factual_category_id": "417",
+      "factual_category_label": "Transportation > Fuel Stations",
+      "is_exact": true
+    }
+  },
+  "19008": {
+    "integrated_label": "Travel and Transportation > Hot Air Balloon Tour Agency",
+    "single_match": {
+      "factual_category_id": "390",
+      "factual_category_label": "Sports and Recreation > Outdoors > Hot Air Balloons",
+      "is_exact": true
+    }
+  },
+  "19009": {
+    "integrated_label": "Travel and Transportation > Lodging",
+    "single_match": {
+      "factual_category_id": "432",
+      "factual_category_label": "Travel > Lodging",
+      "is_exact": true
+    }
+  },
+  "19010": {
+    "integrated_label": "Travel and Transportation > Lodging > Bed and Breakfast",
+    "single_match": {
+      "factual_category_id": "433",
+      "factual_category_label": "Travel > Lodging > Bed and Breakfasts",
+      "is_exact": true
+    }
+  },
+  "19011": {
+    "integrated_label": "Travel and Transportation > Lodging > Boarding House",
+    "single_match": {
+      "factual_category_id": "297",
+      "factual_category_label": "Businesses and Services > Real Estate > Boarding Houses",
+      "is_exact": true
+    }
+  },
+  "19012": {
+    "integrated_label": "Travel and Transportation > Lodging > Cottage / Cabin",
+    "single_match": {
+      "factual_category_id": "434",
+      "factual_category_label": "Travel > Lodging > Cottages and Cabins",
+      "is_exact": true
+    }
+  },
+  "19013": {
+    "integrated_label": "Travel and Transportation > Lodging > Hostel",
+    "single_match": {
+      "factual_category_id": "435",
+      "factual_category_label": "Travel > Lodging > Hostels",
+      "is_exact": true
+    }
+  },
+  "19014": {
+    "integrated_label": "Travel and Transportation > Lodging > Hotel",
+    "single_match": {
+      "factual_category_id": "436",
+      "factual_category_label": "Travel > Lodging > Hotels and Motels",
+      "is_exact": false
+    }
+  },
+  "19015": {
+    "integrated_label": "Travel and Transportation > Lodging > Inn",
+    "single_match": {
+      "factual_category_id": "432",
+      "factual_category_label": "Travel > Lodging",
+      "is_exact": false
+    }
+  },
+  "19016": {
+    "integrated_label": "Travel and Transportation > Lodging > Lodge",
+    "single_match": {
+      "factual_category_id": "437",
+      "factual_category_label": "Travel > Lodging > Lodges and Vacation Rentals",
+      "is_exact": false
+    }
+  },
+  "19017": {
+    "integrated_label": "Travel and Transportation > Lodging > Motel",
+    "single_match": {
+      "factual_category_id": "436",
+      "factual_category_label": "Travel > Lodging > Hotels and Motels",
+      "is_exact": false
+    }
+  },
+  "19018": {
+    "integrated_label": "Travel and Transportation > Lodging > Resort",
+    "single_match": {
+      "factual_category_id": "438",
+      "factual_category_label": "Travel > Lodging > Resorts",
+      "is_exact": true
+    }
+  },
+  "19019": {
+    "integrated_label": "Travel and Transportation > Lodging > Vacation Rental",
+    "single_match": {
+      "factual_category_id": "437",
+      "factual_category_label": "Travel > Lodging > Lodges and Vacation Rentals",
+      "is_exact": false
+    }
+  },
+  "19020": {
+    "integrated_label": "Travel and Transportation > Parking",
+    "single_match": {
+      "factual_category_id": "418",
+      "factual_category_label": "Transportation > Parking",
+      "is_exact": true
+    }
+  },
+  "19021": {
+    "integrated_label": "Travel and Transportation > Pier",
+    "single_match": {
+      "factual_category_id": "430",
+      "factual_category_label": "Travel",
+      "is_exact": false
+    }
+  },
+  "19022": {
+    "integrated_label": "Travel and Transportation > Platform",
+    "single_match": {
+      "factual_category_id": "430",
+      "factual_category_label": "Travel",
+      "is_exact": false
+    }
+  },
+  "19023": {
+    "integrated_label": "Travel and Transportation > Port",
+    "single_match": {
+      "factual_category_id": "430",
+      "factual_category_label": "Travel",
+      "is_exact": false
+    }
+  },
+  "19024": {
+    "integrated_label": "Travel and Transportation > Rest Area",
+    "single_match": {
+      "factual_category_id": "459",
+      "factual_category_label": "Transportation > Rest Areas",
+      "is_exact": true
+    }
+  },
+  "19025": {
+    "integrated_label": "Travel and Transportation > RV Park",
+    "single_match": {
+      "factual_category_id": "388",
+      "factual_category_label": "Sports and Recreation > Outdoors > Campgrounds and RV Parks",
+      "is_exact": true
+    }
+  },
+  "19026": {
+    "integrated_label": "Travel and Transportation > Toll Booth",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19027": {
+    "integrated_label": "Travel and Transportation > Toll Plaza",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19028": {
+    "integrated_label": "Travel and Transportation > Tourist Information and Service",
+    "single_match": {
+      "factual_category_id": "439",
+      "factual_category_label": "Travel > Tourist Information and Services",
+      "is_exact": true
+    }
+  },
+  "19029": {
+    "integrated_label": "Travel and Transportation > Tourist Information and Service > Tour Provider",
+    "single_match": {
+      "factual_category_id": "440",
+      "factual_category_label": "Travel > Travel Agents and Tour Operators",
+      "is_exact": false
+    }
+  },
+  "19030": {
+    "integrated_label": "Travel and Transportation > Transport Hub",
+    "single_match": {
+      "factual_category_id": "424",
+      "factual_category_label": "Transportation > Transport Hubs",
+      "is_exact": true
+    }
+  },
+  "19031": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport",
+    "single_match": {
+      "factual_category_id": "425",
+      "factual_category_label": "Transportation > Transport Hubs > Airports",
+      "is_exact": true
+    }
+  },
+  "19032": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airfield",
+    "single_match": {
+      "factual_category_id": "425",
+      "factual_category_label": "Transportation > Transport Hubs > Airports",
+      "is_exact": false
+    }
+  },
+  "19033": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Food Court",
+    "single_match": {
+      "factual_category_id": "425",
+      "factual_category_label": "Transportation > Transport Hubs > Airports",
+      "is_exact": false
+    }
+  },
+  "19034": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Gate",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19035": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Lounge",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19036": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Service",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19037": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Terminal",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19038": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Tram Station",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19039": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Baggage Claim",
+    "single_match": {
+      "factual_category_id": "416",
+      "factual_category_label": "Transportation > Airlines and Aviation Services",
+      "is_exact": false
+    }
+  },
+  "19040": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > International Airport",
+    "single_match": {
+      "factual_category_id": "425",
+      "factual_category_label": "Transportation > Transport Hubs > Airports",
+      "is_exact": false
+    }
+  },
+  "19041": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Private Airport",
+    "single_match": {
+      "factual_category_id": "425",
+      "factual_category_label": "Transportation > Transport Hubs > Airports",
+      "is_exact": false
+    }
+  },
+  "19042": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Bus Station",
+    "single_match": {
+      "factual_category_id": "426",
+      "factual_category_label": "Transportation > Transport Hubs > Bus Stations",
+      "is_exact": true
+    }
+  },
+  "19043": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Bus Stop",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19044": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Heliport",
+    "single_match": {
+      "factual_category_id": "427",
+      "factual_category_label": "Transportation > Transport Hubs > Heliports",
+      "is_exact": true
+    }
+  },
+  "19045": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Marine Terminal",
+    "single_match": {
+      "factual_category_id": "424",
+      "factual_category_label": "Transportation > Transport Hubs",
+      "is_exact": false
+    }
+  },
+  "19046": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Metro Station",
+    "single_match": {
+      "factual_category_id": "424",
+      "factual_category_label": "Transportation > Transport Hubs",
+      "is_exact": false
+    }
+  },
+  "19047": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Rail Station",
+    "single_match": {
+      "factual_category_id": "429",
+      "factual_category_label": "Transportation > Transport Hubs > Rail Stations",
+      "is_exact": true
+    }
+  },
+  "19048": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Rental Car Location",
+    "single_match": {
+      "factual_category_id": "421",
+      "factual_category_label": "Transportation > Taxi and Car Services > Car and Truck Rentals",
+      "is_exact": true
+    }
+  },
+  "19049": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Taxi Stand",
+    "single_match": {
+      "factual_category_id": "420",
+      "factual_category_label": "Transportation > Taxi and Car Services",
+      "is_exact": true
+    }
+  },
+  "19050": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Tram Station",
+    "single_match": {
+      "factual_category_id": "424",
+      "factual_category_label": "Transportation > Transport Hubs",
+      "is_exact": false
+    }
+  },
+  "19051": {
+    "integrated_label": "Travel and Transportation > Transportation Service",
+    "single_match": {
+      "factual_category_id": "415",
+      "factual_category_label": "Transportation",
+      "is_exact": false
+    }
+  },
+  "19052": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Charter Bus",
+    "single_match": {
+      "factual_category_id": "422",
+      "factual_category_label": "Transportation > Taxi and Car Services > Charter Buses",
+      "is_exact": true
+    }
+  },
+  "19053": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Limo / Chauffeur",
+    "single_match": {
+      "factual_category_id": "423",
+      "factual_category_label": "Transportation > Taxi and Car Services > Limos and Chauffeurs",
+      "is_exact": true
+    }
+  },
+  "19054": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Public Transportation",
+    "single_match": {
+      "factual_category_id": "419",
+      "factual_category_label": "Transportation > Public Transportation Services",
+      "is_exact": true
+    }
+  },
+  "19055": {
+    "integrated_label": "Travel and Transportation > Travel Agency",
+    "single_match": {
+      "factual_category_id": "440",
+      "factual_category_label": "Travel > Travel Agents and Tour Operators",
+      "is_exact": false
+    }
+  },
+  "19056": {
+    "integrated_label": "Travel and Transportation > Travel Lounge",
+    "single_match": {
+      "factual_category_id": "430",
+      "factual_category_label": "Travel",
+      "is_exact": false
+    }
+  }
+}

--- a/categories/integrated_places_files/integrated_to_foursquare.json
+++ b/categories/integrated_places_files/integrated_to_foursquare.json
@@ -1,0 +1,9162 @@
+{
+  "10000": {
+    "integrated_label": "Arts and Entertainment",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": true
+    }
+  },
+  "10001": {
+    "integrated_label": "Arts and Entertainment > Amusement Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d182941735",
+      "foursquare_category_label": "Arts & Entertainment > Theme Park",
+      "is_exact": true
+    }
+  },
+  "10002": {
+    "integrated_label": "Arts and Entertainment > Aquarium",
+    "single_match": {
+      "foursquare_category_id": "4fceea171983d5d06c3e9823",
+      "foursquare_category_label": "Arts & Entertainment > Aquarium",
+      "is_exact": true
+    }
+  },
+  "10003": {
+    "integrated_label": "Arts and Entertainment > Arcade",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e1931735",
+      "foursquare_category_label": "Arts & Entertainment > Arcade",
+      "is_exact": true
+    }
+  },
+  "10004": {
+    "integrated_label": "Arts and Entertainment > Art Gallery",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e2931735",
+      "foursquare_category_label": "Arts & Entertainment > Art Gallery",
+      "is_exact": true
+    }
+  },
+  "10005": {
+    "integrated_label": "Arts and Entertainment > Bingo Center",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10006": {
+    "integrated_label": "Arts and Entertainment > Bowling Alley",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e4931735",
+      "foursquare_category_label": "Arts & Entertainment > Bowling Alley",
+      "is_exact": true
+    }
+  },
+  "10007": {
+    "integrated_label": "Arts and Entertainment > Carnival",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10008": {
+    "integrated_label": "Arts and Entertainment > Casino",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d17c941735",
+      "foursquare_category_label": "Arts & Entertainment > Casino",
+      "is_exact": true
+    }
+  },
+  "10009": {
+    "integrated_label": "Arts and Entertainment > Circus",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79e7",
+      "foursquare_category_label": "Arts & Entertainment > Circus",
+      "is_exact": true
+    }
+  },
+  "10010": {
+    "integrated_label": "Arts and Entertainment > Comedy Club",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d18e941735",
+      "foursquare_category_label": "Arts & Entertainment > Comedy Club",
+      "is_exact": true
+    }
+  },
+  "10011": {
+    "integrated_label": "Arts and Entertainment > Country Club",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10012": {
+    "integrated_label": "Arts and Entertainment > Country Dance Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79ef",
+      "foursquare_category_label": "Arts & Entertainment > Country Dance Club",
+      "is_exact": true
+    }
+  },
+  "10013": {
+    "integrated_label": "Arts and Entertainment > Dance Hall",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10014": {
+    "integrated_label": "Arts and Entertainment > Disc Golf Course",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79e8",
+      "foursquare_category_label": "Arts & Entertainment > Disc Golf",
+      "is_exact": true
+    }
+  },
+  "10015": {
+    "integrated_label": "Arts and Entertainment > Escape Room",
+    "single_match": {
+      "foursquare_category_id": "5f2c2834b6d05514c704451e",
+      "foursquare_category_label": "Arts & Entertainment > Escape Room",
+      "is_exact": true
+    }
+  },
+  "10016": {
+    "integrated_label": "Arts and Entertainment > Exhibit",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573532",
+      "foursquare_category_label": "Arts & Entertainment > Exhibit",
+      "is_exact": true
+    }
+  },
+  "10017": {
+    "integrated_label": "Arts and Entertainment > Fair",
+    "single_match": {
+      "foursquare_category_id": "4eb1daf44b900d56c88a4600",
+      "foursquare_category_label": "Professional & Other Places > Fair",
+      "is_exact": true
+    }
+  },
+  "10018": {
+    "integrated_label": "Arts and Entertainment > Gaming Cafe",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d18d941735",
+      "foursquare_category_label": "Shop & Service > Gaming Cafe",
+      "is_exact": true
+    }
+  },
+  "10019": {
+    "integrated_label": "Arts and Entertainment > Go Kart Track",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79ea",
+      "foursquare_category_label": "Arts & Entertainment > Go Kart Track",
+      "is_exact": true
+    }
+  },
+  "10020": {
+    "integrated_label": "Arts and Entertainment > Internet Cafe",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f0941735",
+      "foursquare_category_label": "Shop & Service > Internet Cafe",
+      "is_exact": true
+    }
+  },
+  "10021": {
+    "integrated_label": "Arts and Entertainment > Karaoke Box",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4bb",
+      "foursquare_category_label": "Arts & Entertainment > Karaoke Box",
+      "is_exact": true
+    }
+  },
+  "10022": {
+    "integrated_label": "Arts and Entertainment > Laser Tag Center",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79e6",
+      "foursquare_category_label": "Arts & Entertainment > Laser Tag",
+      "is_exact": true
+    }
+  },
+  "10023": {
+    "integrated_label": "Arts and Entertainment > Mini Golf Course",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79eb",
+      "foursquare_category_label": "Arts & Entertainment > Mini Golf",
+      "is_exact": true
+    }
+  },
+  "10024": {
+    "integrated_label": "Arts and Entertainment > Movie Theater",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d17f941735",
+      "foursquare_category_label": "Arts & Entertainment > Movie Theater",
+      "is_exact": true
+    }
+  },
+  "10025": {
+    "integrated_label": "Arts and Entertainment > Movie Theater > Drive-in Theater",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734de",
+      "foursquare_category_label": "Arts & Entertainment > Movie Theater > Drive-in Theater",
+      "is_exact": true
+    }
+  },
+  "10026": {
+    "integrated_label": "Arts and Entertainment > Movie Theater > Indie Movie Theater",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d17e941735",
+      "foursquare_category_label": "Arts & Entertainment > Movie Theater > Indie Movie Theater",
+      "is_exact": true
+    }
+  },
+  "10027": {
+    "integrated_label": "Arts and Entertainment > Museum",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d181941735",
+      "foursquare_category_label": "Arts & Entertainment > Museum",
+      "is_exact": true
+    }
+  },
+  "10028": {
+    "integrated_label": "Arts and Entertainment > Museum > Art Museum",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d18f941735",
+      "foursquare_category_label": "Arts & Entertainment > Museum > Art Museum",
+      "is_exact": true
+    }
+  },
+  "10029": {
+    "integrated_label": "Arts and Entertainment > Museum > Erotic Museum",
+    "single_match": {
+      "foursquare_category_id": "559acbe0498e472f1a53fa23",
+      "foursquare_category_label": "Arts & Entertainment > Museum > Erotic Museum",
+      "is_exact": true
+    }
+  },
+  "10030": {
+    "integrated_label": "Arts and Entertainment > Museum > History Museum",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d190941735",
+      "foursquare_category_label": "Arts & Entertainment > Museum > History Museum",
+      "is_exact": true
+    }
+  },
+  "10031": {
+    "integrated_label": "Arts and Entertainment > Museum > Science Museum",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d191941735",
+      "foursquare_category_label": "Arts & Entertainment > Museum > Science Museum",
+      "is_exact": true
+    }
+  },
+  "10032": {
+    "integrated_label": "Arts and Entertainment > Night Club",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11f941735",
+      "foursquare_category_label": "Nightlife Spot > Nightclub",
+      "is_exact": true
+    }
+  },
+  "10033": {
+    "integrated_label": "Arts and Entertainment > Pachinko Parlor",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4b8",
+      "foursquare_category_label": "Arts & Entertainment > Pachinko Parlor",
+      "is_exact": true
+    }
+  },
+  "10034": {
+    "integrated_label": "Arts and Entertainment > Party Center",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10035": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2931735",
+      "foursquare_category_label": "Arts & Entertainment > Performing Arts Venue",
+      "is_exact": true
+    }
+  },
+  "10036": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Amphitheater",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734db",
+      "foursquare_category_label": "Arts & Entertainment > Amphitheater",
+      "is_exact": true
+    }
+  },
+  "10037": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Concert Hall",
+    "single_match": {
+      "foursquare_category_id": "5032792091d4c4b30a586d5c",
+      "foursquare_category_label": "Arts & Entertainment > Concert Hall",
+      "is_exact": true
+    }
+  },
+  "10038": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Indie Theater",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d135941735",
+      "foursquare_category_label": "Arts & Entertainment > Performing Arts Venue > Indie Theater",
+      "is_exact": true
+    }
+  },
+  "10039": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e5931735",
+      "foursquare_category_label": "Arts & Entertainment > Music Venue",
+      "is_exact": true
+    }
+  },
+  "10040": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue > Jazz and Blues Venue",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e7931735",
+      "foursquare_category_label": "Arts & Entertainment > Music Venue > Jazz Club",
+      "is_exact": true
+    }
+  },
+  "10041": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Music Venue > Rock Club",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e9931735",
+      "foursquare_category_label": "Arts & Entertainment > Music Venue > Rock Club",
+      "is_exact": true
+    }
+  },
+  "10042": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Opera House",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d136941735",
+      "foursquare_category_label": "Arts & Entertainment > Performing Arts Venue > Opera House",
+      "is_exact": true
+    }
+  },
+  "10043": {
+    "integrated_label": "Arts and Entertainment > Performing Arts Venue > Theater",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d137941735",
+      "foursquare_category_label": "Arts & Entertainment > Performing Arts Venue > Theater",
+      "is_exact": true
+    }
+  },
+  "10044": {
+    "integrated_label": "Arts and Entertainment > Planetarium",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d192941735",
+      "foursquare_category_label": "Arts & Entertainment > Museum > Planetarium",
+      "is_exact": true
+    }
+  },
+  "10045": {
+    "integrated_label": "Arts and Entertainment > Pool Hall",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e3931735",
+      "foursquare_category_label": "Arts & Entertainment > Pool Hall",
+      "is_exact": true
+    }
+  },
+  "10046": {
+    "integrated_label": "Arts and Entertainment > Psychics and Astrologers",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b43",
+      "foursquare_category_label": "Shop & Service > Astrologer",
+      "is_exact": true
+    }
+  },
+  "10047": {
+    "integrated_label": "Arts and Entertainment > Public Art",
+    "single_match": {
+      "foursquare_category_id": "507c8c4091d498d9fc8c67a9",
+      "foursquare_category_label": "Arts & Entertainment > Public Art",
+      "is_exact": true
+    }
+  },
+  "10048": {
+    "integrated_label": "Arts and Entertainment > Roller Rink",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79e9",
+      "foursquare_category_label": "Arts & Entertainment > Roller Rink",
+      "is_exact": true
+    }
+  },
+  "10049": {
+    "integrated_label": "Arts and Entertainment > Salsa Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79ec",
+      "foursquare_category_label": "Arts & Entertainment > Salsa Club",
+      "is_exact": true
+    }
+  },
+  "10050": {
+    "integrated_label": "Arts and Entertainment > Samba School",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734f9",
+      "foursquare_category_label": "Arts & Entertainment > Samba School",
+      "is_exact": true
+    }
+  },
+  "10051": {
+    "integrated_label": "Arts and Entertainment > Stadium",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d184941735",
+      "foursquare_category_label": "Arts & Entertainment > Stadium",
+      "is_exact": true
+    }
+  },
+  "10052": {
+    "integrated_label": "Arts and Entertainment > Strip Club",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d6941735",
+      "foursquare_category_label": "Nightlife Spot > Strip Club",
+      "is_exact": true
+    }
+  },
+  "10053": {
+    "integrated_label": "Arts and Entertainment > Ticket Seller",
+    "single_match": {
+      "foursquare_category_id": "4d4b7104d754a06370d81259",
+      "foursquare_category_label": "Arts & Entertainment",
+      "is_exact": false
+    }
+  },
+  "10054": {
+    "integrated_label": "Arts and Entertainment > VR Cafe",
+    "single_match": {
+      "foursquare_category_id": "5f2c14a5b6d05514c7042eb7",
+      "foursquare_category_label": "Arts & Entertainment > VR Cafe",
+      "is_exact": true
+    }
+  },
+  "10055": {
+    "integrated_label": "Arts and Entertainment > Water Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d193941735",
+      "foursquare_category_label": "Arts & Entertainment > Water Park",
+      "is_exact": true
+    }
+  },
+  "10056": {
+    "integrated_label": "Arts and Entertainment > Zoo",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d17b941735",
+      "foursquare_category_label": "Arts & Entertainment > Zoo",
+      "is_exact": true
+    }
+  },
+  "11000": {
+    "integrated_label": "Business and Professional Services",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": true
+    }
+  },
+  "11001": {
+    "integrated_label": "Business and Professional Services > Advertising Agency",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3d",
+      "foursquare_category_label": "Professional & Other Places > Office > Advertising Agency",
+      "is_exact": true
+    }
+  },
+  "11002": {
+    "integrated_label": "Business and Professional Services > Agriculture and Forestry Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11003": {
+    "integrated_label": "Business and Professional Services > Architecture Firm",
+    "single_match": {
+      "foursquare_category_id": "5fac002599ce226e27fe72e5",
+      "foursquare_category_label": "Professional & Other Places > Architecture Firm",
+      "is_exact": true
+    }
+  },
+  "11004": {
+    "integrated_label": "Business and Professional Services > Art Restoration Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11005": {
+    "integrated_label": "Business and Professional Services > Art Studio",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1d6",
+      "foursquare_category_label": "Professional & Other Places > Art Studio",
+      "is_exact": true
+    }
+  },
+  "11006": {
+    "integrated_label": "Business and Professional Services > Audiovisual Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11007": {
+    "integrated_label": "Business and Professional Services > Auditorium",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d173941735",
+      "foursquare_category_label": "Professional & Other Places > Auditorium",
+      "is_exact": true
+    }
+  },
+  "11008": {
+    "integrated_label": "Business and Professional Services > Automation and Control System",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11009": {
+    "integrated_label": "Business and Professional Services > Automotive Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": true
+    }
+  },
+  "11010": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Automotive Repair Shop",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11011": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Car Wash and Detail",
+    "single_match": {
+      "foursquare_category_id": "4f04ae1f2fb6e1c99f3db0ba",
+      "foursquare_category_label": "Shop & Service > Car Wash",
+      "is_exact": true
+    }
+  },
+  "11012": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Motorcycle Repair Shop",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11013": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Oil Change Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11014": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Smog Check Shop",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11015": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Tire Repair Shop",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11016": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Towing Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11017": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Transmissions Shop",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d3",
+      "foursquare_category_label": "Shop & Service > Auto Workshop",
+      "is_exact": false
+    }
+  },
+  "11018": {
+    "integrated_label": "Business and Professional Services > Automotive Service > Vehicle Inspection Station",
+    "single_match": {
+      "foursquare_category_id": "5f2c1e0db6d05514c70436d4",
+      "foursquare_category_label": "Shops & Services > Vehicle Inspection Station",
+      "is_exact": true
+    }
+  },
+  "11019": {
+    "integrated_label": "Business and Professional Services > Ballroom",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734cf",
+      "foursquare_category_label": "Professional & Other Places > Ballroom",
+      "is_exact": true
+    }
+  },
+  "11020": {
+    "integrated_label": "Business and Professional Services > Business and Strategy Consulting Office",
+    "single_match": {
+      "foursquare_category_id": "5453de49498eade8af355881",
+      "foursquare_category_label": "Shop & Service > Business Service",
+      "is_exact": false
+    }
+  },
+  "11021": {
+    "integrated_label": "Business and Professional Services > Business Center",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573517",
+      "foursquare_category_label": "Professional & Other Places > Business Center",
+      "is_exact": true
+    }
+  },
+  "11022": {
+    "integrated_label": "Business and Professional Services > Campaign Office",
+    "single_match": {
+      "foursquare_category_id": "5032764e91d4c4b30a586d5a",
+      "foursquare_category_label": "Professional & Other Places > Office > Campaign Office",
+      "is_exact": true
+    }
+  },
+  "11023": {
+    "integrated_label": "Business and Professional Services > Career Counselor",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11024": {
+    "integrated_label": "Business and Professional Services > Chemicals and Gasses Manufacturer",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11025": {
+    "integrated_label": "Business and Professional Services > Child Care Service",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4c7",
+      "foursquare_category_label": "Shop & Service > Child Care Service",
+      "is_exact": true
+    }
+  },
+  "11026": {
+    "integrated_label": "Business and Professional Services > Child Care Service > Daycare",
+    "single_match": {
+      "foursquare_category_id": "4f4532974b9074f6e4fb0104",
+      "foursquare_category_label": "Shop & Service > Child Care Service > Daycare",
+      "is_exact": true
+    }
+  },
+  "11027": {
+    "integrated_label": "Business and Professional Services > Computer Repair Service",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2f",
+      "foursquare_category_label": "Shop & Service > Other Repair Shop",
+      "is_exact": false
+    }
+  },
+  "11028": {
+    "integrated_label": "Business and Professional Services > Construction",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": true
+    }
+  },
+  "11029": {
+    "integrated_label": "Business and Professional Services > Convention Center",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ff931735",
+      "foursquare_category_label": "Professional & Other Places > Convention Center",
+      "is_exact": true
+    }
+  },
+  "11030": {
+    "integrated_label": "Business and Professional Services > Design Studio",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f4941735",
+      "foursquare_category_label": "Shop & Service > Design Studio",
+      "is_exact": true
+    }
+  },
+  "11031": {
+    "integrated_label": "Business and Professional Services > Distribution Center",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a37",
+      "foursquare_category_label": "Professional & Other Places > Distribution Center",
+      "is_exact": true
+    }
+  },
+  "11032": {
+    "integrated_label": "Business and Professional Services > Electrical Equipment Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11033": {
+    "integrated_label": "Business and Professional Services > Employment Agency",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b57",
+      "foursquare_category_label": "Professional & Other Places > Recruiting Agency",
+      "is_exact": true
+    }
+  },
+  "11034": {
+    "integrated_label": "Business and Professional Services > Engineer",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11035": {
+    "integrated_label": "Business and Professional Services > Entertainment Agency",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11036": {
+    "integrated_label": "Business and Professional Services > Entertainment Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573554",
+      "foursquare_category_label": "Shop & Service > Entertainment Service",
+      "is_exact": true
+    }
+  },
+  "11037": {
+    "integrated_label": "Business and Professional Services > Equipment Rental Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573552",
+      "foursquare_category_label": "Shop & Service > Rental Service",
+      "is_exact": false
+    }
+  },
+  "11038": {
+    "integrated_label": "Business and Professional Services > Event Service",
+    "single_match": {
+      "foursquare_category_id": "5454152e498ef71e2b9132c6",
+      "foursquare_category_label": "Shop & Service > Event Service",
+      "is_exact": true
+    }
+  },
+  "11039": {
+    "integrated_label": "Business and Professional Services > Event Space",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d171941735",
+      "foursquare_category_label": "Professional & Other Places > Event Space",
+      "is_exact": true
+    }
+  },
+  "11040": {
+    "integrated_label": "Business and Professional Services > Factory",
+    "single_match": {
+      "foursquare_category_id": "4eb1bea83b7b6f98df247e06",
+      "foursquare_category_label": "Professional & Other Places > Factory",
+      "is_exact": true
+    }
+  },
+  "11041": {
+    "integrated_label": "Business and Professional Services > Film Studio",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573523",
+      "foursquare_category_label": "Shop & Service > Film Studio",
+      "is_exact": true
+    }
+  },
+  "11042": {
+    "integrated_label": "Business and Professional Services > Financial Service",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11043": {
+    "integrated_label": "Business and Professional Services > Financial Service > Accounting and Bookkeeping Service",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11044": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > ATM",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b56",
+      "foursquare_category_label": "Shop & Service > ATM",
+      "is_exact": true
+    }
+  },
+  "11045": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > Bank",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10a951735",
+      "foursquare_category_label": "Shop & Service > Bank",
+      "is_exact": true
+    }
+  },
+  "11046": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11047": {
+    "integrated_label": "Business and Professional Services > Financial Service > Business Broker",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11048": {
+    "integrated_label": "Business and Professional Services > Financial Service > Check Cashing Service",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2d",
+      "foursquare_category_label": "Shop & Service > Check Cashing Service",
+      "is_exact": true
+    }
+  },
+  "11049": {
+    "integrated_label": "Business and Professional Services > Financial Service > Collections Service",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11050": {
+    "integrated_label": "Business and Professional Services > Financial Service > Credit Counseling and Bankruptcy Service",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11051": {
+    "integrated_label": "Business and Professional Services > Financial Service > Banking and Finance > Credit Union",
+    "single_match": {
+      "foursquare_category_id": "5032850891d4c4b30a586d62",
+      "foursquare_category_label": "Shop & Service > Credit Union",
+      "is_exact": true
+    }
+  },
+  "11052": {
+    "integrated_label": "Business and Professional Services > Financial Service > Currency Exchange",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4be",
+      "foursquare_category_label": "Shop & Service > Currency Exchange",
+      "is_exact": true
+    }
+  },
+  "11053": {
+    "integrated_label": "Business and Professional Services > Financial Service > Financial Planner",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11054": {
+    "integrated_label": "Business and Professional Services > Financial Service > Loans Agency",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11055": {
+    "integrated_label": "Business and Professional Services > Financial Service > Stock Broker",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11056": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573550",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Food Service",
+      "is_exact": true
+    }
+  },
+  "11057": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service > Caterer",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573550",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Food Service",
+      "is_exact": false
+    }
+  },
+  "11058": {
+    "integrated_label": "Business and Professional Services > Food and Beverage Service > Food Distribution Center",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573550",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Food Service",
+      "is_exact": false
+    }
+  },
+  "11059": {
+    "integrated_label": "Business and Professional Services > Funeral Home",
+    "single_match": {
+      "foursquare_category_id": "4f4534884b9074f6e4fb0174",
+      "foursquare_category_label": "Professional & Other Places > Funeral Home",
+      "is_exact": true
+    }
+  },
+  "11060": {
+    "integrated_label": "Business and Professional Services > Geological Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11061": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service",
+    "single_match": {
+      "foursquare_category_id": "54541900498ea6ccd0202697",
+      "foursquare_category_label": "Shop & Service > Health & Beauty Service",
+      "is_exact": true
+    }
+  },
+  "11062": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Barbershop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d110951735",
+      "foursquare_category_label": "Shop & Service > Salon / Barbershop",
+      "is_exact": true
+    }
+  },
+  "11063": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Bath House",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a27",
+      "foursquare_category_label": "Shop & Service > Bath House",
+      "is_exact": true
+    }
+  },
+  "11064": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Hair Salon",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d110951735",
+      "foursquare_category_label": "Shop & Service > Salon / Barbershop",
+      "is_exact": true
+    }
+  },
+  "11065": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Body Piercing Shop",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b20",
+      "foursquare_category_label": "Shop & Service > Piercing Parlor",
+      "is_exact": true
+    }
+  },
+  "11066": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Dry Cleaner",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b1d",
+      "foursquare_category_label": "Shop & Service > Dry Cleaner",
+      "is_exact": true
+    }
+  },
+  "11067": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Hair Removal Service",
+    "single_match": {
+      "foursquare_category_id": "54541900498ea6ccd0202697",
+      "foursquare_category_label": "Shop & Service > Health & Beauty Service",
+      "is_exact": false
+    }
+  },
+  "11068": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Laundromat",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b33",
+      "foursquare_category_label": "Shop & Service > Laundromat",
+      "is_exact": true
+    }
+  },
+  "11069": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Laundry Service",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fc941735",
+      "foursquare_category_label": "Shop & Service > Laundry Service",
+      "is_exact": true
+    }
+  },
+  "11070": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Massage Clinic",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3c",
+      "foursquare_category_label": "Shop & Service > Massage Studio",
+      "is_exact": true
+    }
+  },
+  "11071": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Nail Salon",
+    "single_match": {
+      "foursquare_category_id": "4f04aa0c2fb6e1c99f3db0b8",
+      "foursquare_category_label": "Shop & Service > Nail Salon",
+      "is_exact": true
+    }
+  },
+  "11072": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Skin Care Clinic",
+    "single_match": {
+      "foursquare_category_id": "54541900498ea6ccd0202697",
+      "foursquare_category_label": "Shop & Service > Health & Beauty Service",
+      "is_exact": false
+    }
+  },
+  "11073": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Spa",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ed941735",
+      "foursquare_category_label": "Shop & Service > Spa",
+      "is_exact": true
+    }
+  },
+  "11074": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Tanning Salon",
+    "single_match": {
+      "foursquare_category_id": "4d1cf8421a97d635ce361c31",
+      "foursquare_category_label": "Shop & Service > Tanning Salon",
+      "is_exact": true
+    }
+  },
+  "11075": {
+    "integrated_label": "Business and Professional Services > Health and Beauty Service > Tattoo Parlor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1de931735",
+      "foursquare_category_label": "Shop & Service > Tattoo Parlor",
+      "is_exact": true
+    }
+  },
+  "11076": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11077": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Bathroom Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11078": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Carpenter",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11079": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Carpet and Flooring Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11080": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Chimney Sweep",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11081": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Deck and Patio Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11082": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Doors and Windows Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11083": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Electrician",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11084": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Fence Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11085": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Garage Door Supplier",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11086": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > General Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11087": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Heating, Ventilating and Air Conditioning Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11088": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Home Inspection",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11089": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Home Service",
+    "single_match": {
+      "foursquare_category_id": "545419b1498ea6ccd0202f58",
+      "foursquare_category_label": "Shop & Service > Home Service",
+      "is_exact": false
+    }
+  },
+  "11090": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Interior Designer",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11091": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Kitchen Remodeler",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11092": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Landscaper and Gardener",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11093": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Mover",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11094": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Painter",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11095": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Pest Control Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11096": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Plumber",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11097": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Professional Cleaning Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11098": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Roofer",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11099": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Sewer Contractor",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11100": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Swimming Pool Maintenance and Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11101": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Tree Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11102": {
+    "integrated_label": "Business and Professional Services > Home Improvement Service > Upholstery Service",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "11103": {
+    "integrated_label": "Business and Professional Services > Human Resources Agency",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11104": {
+    "integrated_label": "Business and Professional Services > Import and Export Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11105": {
+    "integrated_label": "Business and Professional Services > Industrial Equipment Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11106": {
+    "integrated_label": "Business and Professional Services > Industrial Estate",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734d7",
+      "foursquare_category_label": "Professional & Other Places > Industrial Estate",
+      "is_exact": true
+    }
+  },
+  "11107": {
+    "integrated_label": "Business and Professional Services > Insurance Agency",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1f1",
+      "foursquare_category_label": "Shop & Service > Insurance Office",
+      "is_exact": true
+    }
+  },
+  "11108": {
+    "integrated_label": "Business and Professional Services > Technology Business > IT Service",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b36",
+      "foursquare_category_label": "Shop & Service > IT Services",
+      "is_exact": true
+    }
+  },
+  "11109": {
+    "integrated_label": "Business and Professional Services > Laboratory",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4d6",
+      "foursquare_category_label": "Professional & Other Places > Laboratory",
+      "is_exact": true
+    }
+  },
+  "11110": {
+    "integrated_label": "Business and Professional Services > Leather Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11111": {
+    "integrated_label": "Business and Professional Services > Legal Service",
+    "single_match": {
+      "foursquare_category_id": "503287a291d4c4b30a586d65",
+      "foursquare_category_label": "Shop & Service > Financial or Legal Service",
+      "is_exact": false
+    }
+  },
+  "11112": {
+    "integrated_label": "Business and Professional Services > Legal Service > Attorney / Law Office",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3f",
+      "foursquare_category_label": "Shop & Service > Lawyer",
+      "is_exact": true
+    }
+  },
+  "11113": {
+    "integrated_label": "Business and Professional Services > Legal Service > Immigration Attorney",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3f",
+      "foursquare_category_label": "Shop & Service > Lawyer",
+      "is_exact": false
+    }
+  },
+  "11114": {
+    "integrated_label": "Business and Professional Services > Legal Service > Notary",
+    "single_match": {
+      "foursquare_category_id": "5ae95d208a6f17002ce792b2",
+      "foursquare_category_label": "Shop & Service > Notary",
+      "is_exact": true
+    }
+  },
+  "11115": {
+    "integrated_label": "Business and Professional Services > Locksmith",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b1e",
+      "foursquare_category_label": "Shop & Service > Locksmith",
+      "is_exact": true
+    }
+  },
+  "11116": {
+    "integrated_label": "Business and Professional Services > Logging Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11117": {
+    "integrated_label": "Business and Professional Services > Lottery Retailer",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b38",
+      "foursquare_category_label": "Shop & Service > Lottery Retailer",
+      "is_exact": true
+    }
+  },
+  "11118": {
+    "integrated_label": "Business and Professional Services > Machine Shop",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11119": {
+    "integrated_label": "Business and Professional Services > Management Consultant",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11120": {
+    "integrated_label": "Business and Professional Services > Manufacturer",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11121": {
+    "integrated_label": "Business and Professional Services > Media Agency",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11122": {
+    "integrated_label": "Business and Professional Services > Metals Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11123": {
+    "integrated_label": "Business and Professional Services > Mobile Company",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11124": {
+    "integrated_label": "Business and Professional Services > Office",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d124941735",
+      "foursquare_category_label": "Professional & Other Places > Office",
+      "is_exact": true
+    }
+  },
+  "11125": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Cafeteria",
+    "single_match": {
+      "foursquare_category_id": "54f4ba06498e2cf5561da814",
+      "foursquare_category_label": "Professional & Other Places > Office > Corporate Cafeteria",
+      "is_exact": true
+    }
+  },
+  "11126": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Coffee Shop",
+    "single_match": {
+      "foursquare_category_id": "5665c7b9498e7d8a4f2c0f06",
+      "foursquare_category_label": "Professional & Other Places > Office > Corporate Coffee Shop",
+      "is_exact": true
+    }
+  },
+  "11127": {
+    "integrated_label": "Business and Professional Services > Office > Corporate Housing Agency",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d124941735",
+      "foursquare_category_label": "Professional & Other Places > Office",
+      "is_exact": false
+    }
+  },
+  "11128": {
+    "integrated_label": "Business and Professional Services > Office > Coworking Space",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d174941735",
+      "foursquare_category_label": "Professional & Other Places > Office > Coworking Space",
+      "is_exact": true
+    }
+  },
+  "11129": {
+    "integrated_label": "Business and Professional Services > Office > Meeting Room",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d100941735",
+      "foursquare_category_label": "Professional & Other Places > Convention Center > Meeting Room",
+      "is_exact": true
+    }
+  },
+  "11130": {
+    "integrated_label": "Business and Professional Services > Office > Office Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d130941735",
+      "foursquare_category_label": "Professional & Other Places > Building",
+      "is_exact": false
+    }
+  },
+  "11131": {
+    "integrated_label": "Business and Professional Services > Outdoor Event Space",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57356a",
+      "foursquare_category_label": "Professional & Other Places > Event Space > Outdoor Event Space",
+      "is_exact": true
+    }
+  },
+  "11132": {
+    "integrated_label": "Business and Professional Services > Paper Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11133": {
+    "integrated_label": "Business and Professional Services > Pet Service",
+    "single_match": {
+      "foursquare_category_id": "5032897c91d4c4b30a586d69",
+      "foursquare_category_label": "Shop & Service > Pet Service",
+      "is_exact": true
+    }
+  },
+  "11134": {
+    "integrated_label": "Business and Professional Services > Pet Service > Pet Grooming Service",
+    "single_match": {
+      "foursquare_category_id": "5032897c91d4c4b30a586d69",
+      "foursquare_category_label": "Shop & Service > Pet Service",
+      "is_exact": false
+    }
+  },
+  "11135": {
+    "integrated_label": "Business and Professional Services > Pet Service > Pet Sitting and Boarding Service",
+    "single_match": {
+      "foursquare_category_id": "5032897c91d4c4b30a586d69",
+      "foursquare_category_label": "Shop & Service > Pet Service",
+      "is_exact": false
+    }
+  },
+  "11136": {
+    "integrated_label": "Business and Professional Services > Petroleum Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11137": {
+    "integrated_label": "Business and Professional Services > Photography Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11138": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photographer",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11139": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photography Lab",
+    "single_match": {
+      "foursquare_category_id": "4eb1bdde3b7b55596b4a7490",
+      "foursquare_category_label": "Shop & Service > Photography Lab",
+      "is_exact": true
+    }
+  },
+  "11140": {
+    "integrated_label": "Business and Professional Services > Photography Service > Photography Studio",
+    "single_match": {
+      "foursquare_category_id": "554a5e17498efabeda6cc559",
+      "foursquare_category_label": "Shop & Service > Photography Studio",
+      "is_exact": true
+    }
+  },
+  "11141": {
+    "integrated_label": "Business and Professional Services > Plastics Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11142": {
+    "integrated_label": "Business and Professional Services > Power Plant",
+    "single_match": {
+      "foursquare_category_id": "58daa1548bbb0b01f18ec1a9",
+      "foursquare_category_label": "Professional & Other Places > Power Plant",
+      "is_exact": true
+    }
+  },
+  "11143": {
+    "integrated_label": "Business and Professional Services > Publisher",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11144": {
+    "integrated_label": "Business and Professional Services > Radio Station",
+    "single_match": {
+      "foursquare_category_id": "5032856091d4c4b30a586d63",
+      "foursquare_category_label": "Professional & Other Places > Radio Station",
+      "is_exact": true
+    }
+  },
+  "11145": {
+    "integrated_label": "Business and Professional Services > Real Estate Service",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": true
+    }
+  },
+  "11146": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Building and Land Surveyor",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11147": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Commercial Real Estate Developer",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11148": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Property Management Office",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11149": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Agency",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11150": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Appraiser",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11151": {
+    "integrated_label": "Business and Professional Services > Real Estate Service > Real Estate Development and Title Company",
+    "single_match": {
+      "foursquare_category_id": "5032885091d4c4b30a586d66",
+      "foursquare_category_label": "Shop & Service > Real Estate Office",
+      "is_exact": false
+    }
+  },
+  "11152": {
+    "integrated_label": "Business and Professional Services > Recording Studio",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b37",
+      "foursquare_category_label": "Shop & Service > Recording Studio",
+      "is_exact": true
+    }
+  },
+  "11153": {
+    "integrated_label": "Business and Professional Services > Recycling Facility",
+    "single_match": {
+      "foursquare_category_id": "4f4531084b9074f6e4fb0101",
+      "foursquare_category_label": "Shop & Service > Recycling Facility",
+      "is_exact": true
+    }
+  },
+  "11154": {
+    "integrated_label": "Business and Professional Services > Refrigeration and Ice Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11155": {
+    "integrated_label": "Business and Professional Services > Renewable Energy Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11156": {
+    "integrated_label": "Business and Professional Services > Rental Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573552",
+      "foursquare_category_label": "Shop & Service > Rental Service",
+      "is_exact": true
+    }
+  },
+  "11157": {
+    "integrated_label": "Business and Professional Services > Repair Service",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2f",
+      "foursquare_category_label": "Shop & Service > Other Repair Shop",
+      "is_exact": false
+    }
+  },
+  "11158": {
+    "integrated_label": "Business and Professional Services > Research Station",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1b2",
+      "foursquare_category_label": "Professional & Other Places > Research Station",
+      "is_exact": true
+    }
+  },
+  "11159": {
+    "integrated_label": "Business and Professional Services > Rubber Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11160": {
+    "integrated_label": "Business and Professional Services > Salvage Yard",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11161": {
+    "integrated_label": "Business and Professional Services > Scientific Equipment Supplier",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11162": {
+    "integrated_label": "Business and Professional Services > Security and Safety",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11163": {
+    "integrated_label": "Business and Professional Services > Shipping, Freight, and Material Transportation Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11164": {
+    "integrated_label": "Business and Professional Services > Shoe Repair Service",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b39",
+      "foursquare_category_label": "Shop & Service > Shoe Repair",
+      "is_exact": true
+    }
+  },
+  "11165": {
+    "integrated_label": "Business and Professional Services > Storage Facility",
+    "single_match": {
+      "foursquare_category_id": "4f04b1572fb6e1c99f3db0bf",
+      "foursquare_category_label": "Shop & Service > Storage Facility",
+      "is_exact": true
+    }
+  },
+  "11166": {
+    "integrated_label": "Business and Professional Services > Tailor",
+    "single_match": {
+      "foursquare_category_id": "5032781d91d4c4b30a586d5b",
+      "foursquare_category_label": "Shop & Service > Tailor Shop",
+      "is_exact": true
+    }
+  },
+  "11167": {
+    "integrated_label": "Business and Professional Services > Technology Business",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d125941735",
+      "foursquare_category_label": "Professional & Other Places > Office > Tech Startup",
+      "is_exact": true
+    }
+  },
+  "11168": {
+    "integrated_label": "Business and Professional Services > Technology Business > Software Company",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d125941735",
+      "foursquare_category_label": "Professional & Other Places > Office > Tech Startup",
+      "is_exact": false
+    }
+  },
+  "11169": {
+    "integrated_label": "Business and Professional Services > Technology Business > Website Designer",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d125941735",
+      "foursquare_category_label": "Professional & Other Places > Office > Tech Startup",
+      "is_exact": false
+    }
+  },
+  "11170": {
+    "integrated_label": "Business and Professional Services > Telecommunication Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11171": {
+    "integrated_label": "Business and Professional Services > Translation Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11172": {
+    "integrated_label": "Business and Professional Services > Tutoring Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11173": {
+    "integrated_label": "Business and Professional Services > TV Station",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a31",
+      "foursquare_category_label": "Professional & Other Places > TV Station",
+      "is_exact": true
+    }
+  },
+  "11174": {
+    "integrated_label": "Business and Professional Services > Warehouse",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a36",
+      "foursquare_category_label": "Professional & Other Places > Warehouse",
+      "is_exact": true
+    }
+  },
+  "11175": {
+    "integrated_label": "Business and Professional Services > Waste Management Service",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1ac",
+      "foursquare_category_label": "Professional & Other Places > Waste Facility",
+      "is_exact": true
+    }
+  },
+  "11176": {
+    "integrated_label": "Business and Professional Services > Water Treatment Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "11177": {
+    "integrated_label": "Business and Professional Services > Wedding Hall",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734c5",
+      "foursquare_category_label": "Professional & Other Places > Wedding Hall",
+      "is_exact": true
+    }
+  },
+  "11178": {
+    "integrated_label": "Business and Professional Services > Welding Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "11179": {
+    "integrated_label": "Business and Professional Services > Wholesaler",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12000": {
+    "integrated_label": "Community and Government",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12001": {
+    "integrated_label": "Community and Government > Addiction Treatment Center",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12002": {
+    "integrated_label": "Community and Government > Animal Shelter",
+    "single_match": {
+      "foursquare_category_id": "4e52d2d203646f7c19daa8ae",
+      "foursquare_category_label": "Professional & Other Places > Animal Shelter",
+      "is_exact": true
+    }
+  },
+  "12003": {
+    "integrated_label": "Community and Government > Cemetery",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d15c941735",
+      "foursquare_category_label": "Outdoors & Recreation > Cemetery",
+      "is_exact": true
+    }
+  },
+  "12004": {
+    "integrated_label": "Community and Government > Community Center",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a34",
+      "foursquare_category_label": "Professional & Other Places > Community Center",
+      "is_exact": true
+    }
+  },
+  "12005": {
+    "integrated_label": "Community and Government > Cultural Center",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a32",
+      "foursquare_category_label": "Professional & Other Places > Cultural Center",
+      "is_exact": true
+    }
+  },
+  "12006": {
+    "integrated_label": "Community and Government > Disabled Persons Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12007": {
+    "integrated_label": "Community and Government > Domestic Abuse Treatment Center",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12008": {
+    "integrated_label": "Community and Government > Dump",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12009": {
+    "integrated_label": "Community and Government > Education",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13b941735",
+      "foursquare_category_label": "Professional & Other Places > School",
+      "is_exact": true
+    }
+  },
+  "12010": {
+    "integrated_label": "Community and Government > Education > Adult Education",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573570",
+      "foursquare_category_label": "Professional & Other Places > School > Adult Education Center",
+      "is_exact": true
+    }
+  },
+  "12011": {
+    "integrated_label": "Community and Government > Education > Art School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13b941735",
+      "foursquare_category_label": "Professional & Other Places > School",
+      "is_exact": false
+    }
+  },
+  "12012": {
+    "integrated_label": "Community and Government > Education > Circus School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a43",
+      "foursquare_category_label": "Professional & Other Places > School > Circus School",
+      "is_exact": true
+    }
+  },
+  "12013": {
+    "integrated_label": "Community and Government > Education > College and University",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06372d81259",
+      "foursquare_category_label": "College & University",
+      "is_exact": true
+    }
+  },
+  "12014": {
+    "integrated_label": "Community and Government > Education > College and University > College Academic Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d198941735",
+      "foursquare_category_label": "College & University > College Academic Building",
+      "is_exact": true
+    }
+  },
+  "12015": {
+    "integrated_label": "Community and Government > Education > College and University > College Administrative Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d197941735",
+      "foursquare_category_label": "College & University > College Administrative Building",
+      "is_exact": true
+    }
+  },
+  "12016": {
+    "integrated_label": "Community and Government > Education > College and University > College Arts Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d199941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Arts Building",
+      "is_exact": true
+    }
+  },
+  "12017": {
+    "integrated_label": "Community and Government > Education > College and University > College Auditorium",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1af941735",
+      "foursquare_category_label": "College & University > College Auditorium",
+      "is_exact": true
+    }
+  },
+  "12018": {
+    "integrated_label": "Community and Government > Education > College and University > College Baseball Diamond",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1bb941735",
+      "foursquare_category_label": "College & University > College Stadium > College Baseball Diamond",
+      "is_exact": true
+    }
+  },
+  "12019": {
+    "integrated_label": "Community and Government > Education > College and University > College Basketball Court",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ba941735",
+      "foursquare_category_label": "College & University > College Stadium > College Basketball Court",
+      "is_exact": true
+    }
+  },
+  "12020": {
+    "integrated_label": "Community and Government > Education > College and University > College Bookstore",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b1941735",
+      "foursquare_category_label": "College & University > College Bookstore",
+      "is_exact": true
+    }
+  },
+  "12021": {
+    "integrated_label": "Community and Government > Education > College and University > College Cafeteria",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a1941735",
+      "foursquare_category_label": "College & University > College Cafeteria",
+      "is_exact": true
+    }
+  },
+  "12022": {
+    "integrated_label": "Community and Government > Education > College and University > College Classroom",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a0941735",
+      "foursquare_category_label": "College & University > College Classroom",
+      "is_exact": true
+    }
+  },
+  "12023": {
+    "integrated_label": "Community and Government > Education > College and University > College Communications Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19a941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Communications Building",
+      "is_exact": true
+    }
+  },
+  "12024": {
+    "integrated_label": "Community and Government > Education > College and University > College Cricket Pitch",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b9941735",
+      "foursquare_category_label": "College & University > College Stadium > College Cricket Pitch",
+      "is_exact": true
+    }
+  },
+  "12025": {
+    "integrated_label": "Community and Government > Education > College and University > College Engineering Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19e941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Engineering Building",
+      "is_exact": true
+    }
+  },
+  "12026": {
+    "integrated_label": "Community and Government > Education > College and University > College Football Field",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b8941735",
+      "foursquare_category_label": "College & University > College Stadium > College Football Field",
+      "is_exact": true
+    }
+  },
+  "12027": {
+    "integrated_label": "Community and Government > Education > College and University > College Gym",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b2941735",
+      "foursquare_category_label": "College & University > College Gym",
+      "is_exact": true
+    }
+  },
+  "12028": {
+    "integrated_label": "Community and Government > Education > College and University > College History Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19d941735",
+      "foursquare_category_label": "College & University > College Academic Building > College History Building",
+      "is_exact": true
+    }
+  },
+  "12029": {
+    "integrated_label": "Community and Government > Education > College and University > College Hockey Rink",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b5941735",
+      "foursquare_category_label": "College & University > College Stadium > College Hockey Rink",
+      "is_exact": true
+    }
+  },
+  "12030": {
+    "integrated_label": "Community and Government > Education > College and University > College Lab",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a5941735",
+      "foursquare_category_label": "College & University > College Lab",
+      "is_exact": true
+    }
+  },
+  "12031": {
+    "integrated_label": "Community and Government > Education > College and University > College Library",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a7941735",
+      "foursquare_category_label": "College & University > College Library",
+      "is_exact": true
+    }
+  },
+  "12032": {
+    "integrated_label": "Community and Government > Education > College and University > College Math Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19c941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Math Building",
+      "is_exact": true
+    }
+  },
+  "12033": {
+    "integrated_label": "Community and Government > Education > College and University > College Quad",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1aa941735",
+      "foursquare_category_label": "College & University > College Quad",
+      "is_exact": true
+    }
+  },
+  "12034": {
+    "integrated_label": "Community and Government > Education > College and University > College Rec Center",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a9941735",
+      "foursquare_category_label": "College & University > College Rec Center",
+      "is_exact": true
+    }
+  },
+  "12035": {
+    "integrated_label": "Community and Government > Education > College and University > College Residence Hall",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a3941735",
+      "foursquare_category_label": "College & University > College Residence Hall",
+      "is_exact": true
+    }
+  },
+  "12036": {
+    "integrated_label": "Community and Government > Education > College and University > College Science Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19b941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Science Building",
+      "is_exact": true
+    }
+  },
+  "12037": {
+    "integrated_label": "Community and Government > Education > College and University > College Soccer Field",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b7941735",
+      "foursquare_category_label": "College & University > College Stadium > College Soccer Field",
+      "is_exact": true
+    }
+  },
+  "12038": {
+    "integrated_label": "Community and Government > Education > College and University > College Stadium",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b4941735",
+      "foursquare_category_label": "College & University > College Stadium",
+      "is_exact": true
+    }
+  },
+  "12039": {
+    "integrated_label": "Community and Government > Education > College and University > College Technology Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d19f941735",
+      "foursquare_category_label": "College & University > College Academic Building > College Technology Building",
+      "is_exact": true
+    }
+  },
+  "12040": {
+    "integrated_label": "Community and Government > Education > College and University > College Tennis Court",
+    "single_match": {
+      "foursquare_category_id": "4e39a9cebd410d7aed40cbc4",
+      "foursquare_category_label": "College & University > College Stadium > College Tennis Court",
+      "is_exact": true
+    }
+  },
+  "12041": {
+    "integrated_label": "Community and Government > Education > College and University > College Theater",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ac941735",
+      "foursquare_category_label": "College & University > College Theater",
+      "is_exact": true
+    }
+  },
+  "12042": {
+    "integrated_label": "Community and Government > Education > College and University > College Track",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b6941735",
+      "foursquare_category_label": "College & University > College Stadium > College Track",
+      "is_exact": true
+    }
+  },
+  "12043": {
+    "integrated_label": "Community and Government > Education > College and University > Fraternity House",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b0941735",
+      "foursquare_category_label": "College & University > Fraternity House",
+      "is_exact": true
+    }
+  },
+  "12044": {
+    "integrated_label": "Community and Government > Education > College and University > Law School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a6941735",
+      "foursquare_category_label": "College & University > Law School",
+      "is_exact": true
+    }
+  },
+  "12045": {
+    "integrated_label": "Community and Government > Education > College and University > Medical School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1b3941735",
+      "foursquare_category_label": "College & University > Medical School",
+      "is_exact": true
+    }
+  },
+  "12046": {
+    "integrated_label": "Community and Government > Education > College and University > Sorority House",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d141941735",
+      "foursquare_category_label": "College & University > Sorority House",
+      "is_exact": true
+    }
+  },
+  "12047": {
+    "integrated_label": "Community and Government > Education > College and University > Student Center",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ab941735",
+      "foursquare_category_label": "College & University > Student Center",
+      "is_exact": true
+    }
+  },
+  "12048": {
+    "integrated_label": "Community and Government > Education > College and University > Community College",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1a2941735",
+      "foursquare_category_label": "College & University > Community College",
+      "is_exact": true
+    }
+  },
+  "12049": {
+    "integrated_label": "Community and Government > Education > Computer Training School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13b941735",
+      "foursquare_category_label": "Professional & Other Places > School",
+      "is_exact": false
+    }
+  },
+  "12050": {
+    "integrated_label": "Community and Government > Education > Culinary School",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec200",
+      "foursquare_category_label": "Professional & Other Places > School > Cooking School",
+      "is_exact": true
+    }
+  },
+  "12051": {
+    "integrated_label": "Community and Government > Education > Driving School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a42",
+      "foursquare_category_label": "Professional & Other Places > School > Driving School",
+      "is_exact": true
+    }
+  },
+  "12052": {
+    "integrated_label": "Community and Government > Education > Flight School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a49",
+      "foursquare_category_label": "Professional & Other Places > School > Flight School",
+      "is_exact": true
+    }
+  },
+  "12053": {
+    "integrated_label": "Community and Government > Education > Language School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a48",
+      "foursquare_category_label": "Professional & Other Places > School > Language School",
+      "is_exact": true
+    }
+  },
+  "12054": {
+    "integrated_label": "Community and Government > Education > Music School",
+    "single_match": {
+      "foursquare_category_id": "4f04b10d2fb6e1c99f3db0be",
+      "foursquare_category_label": "Professional & Other Places > School > Music School",
+      "is_exact": true
+    }
+  },
+  "12055": {
+    "integrated_label": "Community and Government > Education > Nursery School",
+    "single_match": {
+      "foursquare_category_id": "4f4533814b9074f6e4fb0107",
+      "foursquare_category_label": "Professional & Other Places > School > Nursery School",
+      "is_exact": true
+    }
+  },
+  "12056": {
+    "integrated_label": "Community and Government > Education > Preschool",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a45",
+      "foursquare_category_label": "Professional & Other Places > School > Preschool",
+      "is_exact": true
+    }
+  },
+  "12057": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13b941735",
+      "foursquare_category_label": "Professional & Other Places > School",
+      "is_exact": false
+    }
+  },
+  "12058": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > Elementary School",
+    "single_match": {
+      "foursquare_category_id": "4f4533804b9074f6e4fb0105",
+      "foursquare_category_label": "Professional & Other Places > School > Elementary School",
+      "is_exact": true
+    }
+  },
+  "12059": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > High School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13d941735",
+      "foursquare_category_label": "Professional & Other Places > School > High School",
+      "is_exact": true
+    }
+  },
+  "12060": {
+    "integrated_label": "Community and Government > Education > Primary and Secondary School > Middle School",
+    "single_match": {
+      "foursquare_category_id": "4f4533814b9074f6e4fb0106",
+      "foursquare_category_label": "Professional & Other Places > School > Middle School",
+      "is_exact": true
+    }
+  },
+  "12061": {
+    "integrated_label": "Community and Government > Education > Private School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a46",
+      "foursquare_category_label": "Professional & Other Places > School > Private School",
+      "is_exact": true
+    }
+  },
+  "12062": {
+    "integrated_label": "Community and Government > Education > Religious School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a47",
+      "foursquare_category_label": "Professional & Other Places > School > Religious School",
+      "is_exact": true
+    }
+  },
+  "12063": {
+    "integrated_label": "Community and Government > Education > Trade School",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ad941735",
+      "foursquare_category_label": "College & University > Trade School",
+      "is_exact": true
+    }
+  },
+  "12064": {
+    "integrated_label": "Community and Government > Government Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d126941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building",
+      "is_exact": true
+    }
+  },
+  "12065": {
+    "integrated_label": "Community and Government > Government Building > Capitol Building",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12a941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Capitol Building",
+      "is_exact": true
+    }
+  },
+  "12066": {
+    "integrated_label": "Community and Government > Government Building > City Hall",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d129941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > City Hall",
+      "is_exact": true
+    }
+  },
+  "12067": {
+    "integrated_label": "Community and Government > Government Building > Courthouse",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12b941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Courthouse",
+      "is_exact": true
+    }
+  },
+  "12068": {
+    "integrated_label": "Community and Government > Government Building > Embassy / Consulate",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12c951735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Embassy / Consulate",
+      "is_exact": true
+    }
+  },
+  "12069": {
+    "integrated_label": "Community and Government > Government Building > Government Department / Agency",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d126941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building",
+      "is_exact": false
+    }
+  },
+  "12070": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d126941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building",
+      "is_exact": false
+    }
+  },
+  "12071": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Fire Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12c941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Fire Station",
+      "is_exact": true
+    }
+  },
+  "12072": {
+    "integrated_label": "Community and Government > Government Building > Law Enforcement and Public Safety > Police Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12e941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Police Station",
+      "is_exact": true
+    }
+  },
+  "12073": {
+    "integrated_label": "Community and Government > Government Building > Military",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12e941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Police Station",
+      "is_exact": false
+    }
+  },
+  "12074": {
+    "integrated_label": "Community and Government > Government Building > Military > Military Base",
+    "single_match": {
+      "foursquare_category_id": "4e52adeebd41615f56317744",
+      "foursquare_category_label": "Professional & Other Places > Military Base",
+      "is_exact": true
+    }
+  },
+  "12075": {
+    "integrated_label": "Community and Government > Government Building > Post Office",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d172941735",
+      "foursquare_category_label": "Professional & Other Places > Post Office",
+      "is_exact": true
+    }
+  },
+  "12076": {
+    "integrated_label": "Community and Government > Government Lobbyist",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12077": {
+    "integrated_label": "Community and Government > Homeless Shelter",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12078": {
+    "integrated_label": "Community and Government > Housing Authority",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12079": {
+    "integrated_label": "Community and Government > Housing Development",
+    "single_match": {
+      "foursquare_category_id": "4f2a210c4b9023bd5841ed28",
+      "foursquare_category_label": "Residence > Housing Development",
+      "is_exact": true
+    }
+  },
+  "12080": {
+    "integrated_label": "Community and Government > Library",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12f941735",
+      "foursquare_category_label": "Professional & Other Places > Library",
+      "is_exact": true
+    }
+  },
+  "12081": {
+    "integrated_label": "Community and Government > Observatory",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4d9",
+      "foursquare_category_label": "Professional & Other Places > Observatory",
+      "is_exact": true
+    }
+  },
+  "12082": {
+    "integrated_label": "Community and Government > Organization",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12083": {
+    "integrated_label": "Community and Government > Organization > Charity",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12084": {
+    "integrated_label": "Community and Government > Organization > Club House",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a35",
+      "foursquare_category_label": "Professional & Other Places > Club House",
+      "is_exact": true
+    }
+  },
+  "12085": {
+    "integrated_label": "Community and Government > Organization > Environmental Organization",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12086": {
+    "integrated_label": "Community and Government > Organization > Non-Profit Organization",
+    "single_match": {
+      "foursquare_category_id": "50328a8e91d4c4b30a586d6c",
+      "foursquare_category_label": "Professional & Other Places > Non-Profit",
+      "is_exact": true
+    }
+  },
+  "12087": {
+    "integrated_label": "Community and Government > Organization > Social Services Organization",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12088": {
+    "integrated_label": "Community and Government > Organization > Veterans' Organization",
+    "single_match": {
+      "foursquare_category_id": "5f2c5de85b4c177b9a6de29c",
+      "foursquare_category_label": "Professional & Other Places > Social Clubs > Veterans' Organization",
+      "is_exact": true
+    }
+  },
+  "12089": {
+    "integrated_label": "Community and Government > Organization > Youth Organization",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12090": {
+    "integrated_label": "Community and Government > Prison",
+    "single_match": {
+      "foursquare_category_id": "5310b8e5bcbc57f1066bcbf1",
+      "foursquare_category_label": "Professional & Other Places > Prison",
+      "is_exact": true
+    }
+  },
+  "12091": {
+    "integrated_label": "Community and Government > Public and Social Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12092": {
+    "integrated_label": "Community and Government > Public Bathroom",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4c4",
+      "foursquare_category_label": "Shop & Service > Public Bathroom",
+      "is_exact": true
+    }
+  },
+  "12093": {
+    "integrated_label": "Community and Government > Rehabilitation Center",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57351d",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Rehab Center",
+      "is_exact": true
+    }
+  },
+  "12094": {
+    "integrated_label": "Community and Government > Residential Building",
+    "single_match": {
+      "foursquare_category_id": "4d954b06a243a5684965b473",
+      "foursquare_category_label": "Residence > Residential Building (Apartment / Condo)",
+      "is_exact": true
+    }
+  },
+  "12095": {
+    "integrated_label": "Community and Government > Retirement Home",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "12096": {
+    "integrated_label": "Community and Government > Senior Citizen Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12097": {
+    "integrated_label": "Community and Government > Social Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a33",
+      "foursquare_category_label": "Professional & Other Places > Social Club",
+      "is_exact": true
+    }
+  },
+  "12098": {
+    "integrated_label": "Community and Government > Spiritual Center",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d131941735",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center",
+      "is_exact": true
+    }
+  },
+  "12099": {
+    "integrated_label": "Community and Government > Spiritual Center > Buddhist Temple",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3e",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Buddhist Temple",
+      "is_exact": true
+    }
+  },
+  "12100": {
+    "integrated_label": "Community and Government > Spiritual Center > Cemevi",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1eb",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Cemevi",
+      "is_exact": true
+    }
+  },
+  "12101": {
+    "integrated_label": "Community and Government > Spiritual Center > Church",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d132941735",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Church",
+      "is_exact": true
+    }
+  },
+  "12102": {
+    "integrated_label": "Community and Government > Spiritual Center > Confucian Temple",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734fc",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Confucian Temple",
+      "is_exact": true
+    }
+  },
+  "12103": {
+    "integrated_label": "Community and Government > Spiritual Center > Hindu Temple",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3f",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Hindu Temple",
+      "is_exact": true
+    }
+  },
+  "12104": {
+    "integrated_label": "Community and Government > Spiritual Center > Kingdom Hall",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4ac",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Kingdom Hall",
+      "is_exact": true
+    }
+  },
+  "12105": {
+    "integrated_label": "Community and Government > Spiritual Center > Monastery",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a40",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Monastery",
+      "is_exact": true
+    }
+  },
+  "12106": {
+    "integrated_label": "Community and Government > Spiritual Center > Mosque",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d138941735",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Mosque",
+      "is_exact": true
+    }
+  },
+  "12107": {
+    "integrated_label": "Community and Government > Spiritual Center > Prayer Room",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a41",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Prayer Room",
+      "is_exact": true
+    }
+  },
+  "12108": {
+    "integrated_label": "Community and Government > Spiritual Center > Shrine",
+    "single_match": {
+      "foursquare_category_id": "4eb1d80a4b900d56c88a45ff",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Shrine",
+      "is_exact": true
+    }
+  },
+  "12109": {
+    "integrated_label": "Community and Government > Spiritual Center > Sikh Temple",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89c9",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Sikh Temple",
+      "is_exact": true
+    }
+  },
+  "12110": {
+    "integrated_label": "Community and Government > Spiritual Center > Synagogue",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d139941735",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Synagogue",
+      "is_exact": true
+    }
+  },
+  "12111": {
+    "integrated_label": "Community and Government > Spiritual Center > Temple",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d13a941735",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Temple",
+      "is_exact": true
+    }
+  },
+  "12112": {
+    "integrated_label": "Community and Government > Spiritual Center > Terreiro",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734f6",
+      "foursquare_category_label": "Professional & Other Places > Spiritual Center > Terreiro",
+      "is_exact": true
+    }
+  },
+  "12113": {
+    "integrated_label": "Community and Government > Summer Camp",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a10",
+      "foursquare_category_label": "Outdoors & Recreation > Summer Camp",
+      "is_exact": true
+    }
+  },
+  "12114": {
+    "integrated_label": "Community and Government > Trailer Park",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b55",
+      "foursquare_category_label": "Residence > Trailer Park",
+      "is_exact": true
+    }
+  },
+  "12115": {
+    "integrated_label": "Community and Government > Utility Company",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "12116": {
+    "integrated_label": "Community and Government > Polling Place",
+    "single_match": {
+      "foursquare_category_id": "4cae28ecbf23941eb1190695",
+      "foursquare_category_label": "Professional & Other Places > Voting Booth",
+      "is_exact": true
+    }
+  },
+  "13000": {
+    "integrated_label": "Dining and Drinking",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06374d81259",
+      "foursquare_category_label": "Food",
+      "is_exact": true
+    }
+  },
+  "13001": {
+    "integrated_label": "Dining and Drinking > Bagel Shop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d179941735",
+      "foursquare_category_label": "Food > Bagel Shop",
+      "is_exact": true
+    }
+  },
+  "13002": {
+    "integrated_label": "Dining and Drinking > Bakery",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16a941735",
+      "foursquare_category_label": "Food > Bakery",
+      "is_exact": true
+    }
+  },
+  "13003": {
+    "integrated_label": "Dining and Drinking > Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d116941735",
+      "foursquare_category_label": "Nightlife Spot > Bar",
+      "is_exact": true
+    }
+  },
+  "13004": {
+    "integrated_label": "Dining and Drinking > Bar > Apres Ski Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ea941735",
+      "foursquare_category_label": "Outdoors & Recreation > Ski Area > Apres Ski Bar",
+      "is_exact": true
+    }
+  },
+  "13005": {
+    "integrated_label": "Dining and Drinking > Bar > Beach Bar",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a0d",
+      "foursquare_category_label": "Nightlife Spot > Bar > Beach Bar",
+      "is_exact": true
+    }
+  },
+  "13006": {
+    "integrated_label": "Dining and Drinking > Bar > Beer Bar",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57356c",
+      "foursquare_category_label": "Nightlife Spot > Bar > Beer Bar",
+      "is_exact": true
+    }
+  },
+  "13007": {
+    "integrated_label": "Dining and Drinking > Bar > Beer Garden",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d117941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Beer Garden",
+      "is_exact": true
+    }
+  },
+  "13008": {
+    "integrated_label": "Dining and Drinking > Bar > Champagne Bar",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a0e",
+      "foursquare_category_label": "Nightlife Spot > Bar > Champagne Bar",
+      "is_exact": true
+    }
+  },
+  "13009": {
+    "integrated_label": "Dining and Drinking > Bar > Cocktail Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11e941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Cocktail Bar",
+      "is_exact": true
+    }
+  },
+  "13010": {
+    "integrated_label": "Dining and Drinking > Bar > Dive Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d118941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Dive Bar",
+      "is_exact": true
+    }
+  },
+  "13011": {
+    "integrated_label": "Dining and Drinking > Bar > Gay Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d8941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Gay Bar",
+      "is_exact": true
+    }
+  },
+  "13012": {
+    "integrated_label": "Dining and Drinking > Bar > Hookah Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d119941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Hookah Bar",
+      "is_exact": true
+    }
+  },
+  "13013": {
+    "integrated_label": "Dining and Drinking > Bar > Hotel Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d5941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Hotel Bar",
+      "is_exact": true
+    }
+  },
+  "13014": {
+    "integrated_label": "Dining and Drinking > Bar > Ice Bar",
+    "single_match": {
+      "foursquare_category_id": "5f2c40f15b4c177b9a6dc684",
+      "foursquare_category_label": "Nightlife Spots > Bars > Ice Bar",
+      "is_exact": true
+    }
+  },
+  "13015": {
+    "integrated_label": "Dining and Drinking > Bar > Karaoke Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d120941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Karaoke Bar",
+      "is_exact": true
+    }
+  },
+  "13016": {
+    "integrated_label": "Dining and Drinking > Bar > Lounge",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d121941735",
+      "foursquare_category_label": "Nightlife Spot > Lounge",
+      "is_exact": true
+    }
+  },
+  "13017": {
+    "integrated_label": "Dining and Drinking > Bar > Piano Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e8931735",
+      "foursquare_category_label": "Arts & Entertainment > Music Venue > Piano Bar",
+      "is_exact": true
+    }
+  },
+  "13018": {
+    "integrated_label": "Dining and Drinking > Bar > Pub",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11b941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Pub",
+      "is_exact": true
+    }
+  },
+  "13019": {
+    "integrated_label": "Dining and Drinking > Bar > Rooftop Bar",
+    "single_match": {
+      "foursquare_category_id": "5f2c224bb6d05514c70440a3",
+      "foursquare_category_label": "Nightlife Spots > Bars > Rooftop Bar",
+      "is_exact": true
+    }
+  },
+  "13020": {
+    "integrated_label": "Dining and Drinking > Bar > Sake Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11c941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Sake Bar",
+      "is_exact": true
+    }
+  },
+  "13021": {
+    "integrated_label": "Dining and Drinking > Bar > Speakeasy",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d4941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Speakeasy",
+      "is_exact": true
+    }
+  },
+  "13022": {
+    "integrated_label": "Dining and Drinking > Bar > Sports Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11d941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Sports Bar",
+      "is_exact": true
+    }
+  },
+  "13023": {
+    "integrated_label": "Dining and Drinking > Bar > Tiki Bar",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57354d",
+      "foursquare_category_label": "Nightlife Spot > Bar > Tiki Bar",
+      "is_exact": true
+    }
+  },
+  "13024": {
+    "integrated_label": "Dining and Drinking > Bar > Whisky Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d122941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Whisky Bar",
+      "is_exact": true
+    }
+  },
+  "13025": {
+    "integrated_label": "Dining and Drinking > Bar > Wine Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d123941735",
+      "foursquare_category_label": "Nightlife Spot > Bar > Wine Bar",
+      "is_exact": true
+    }
+  },
+  "13026": {
+    "integrated_label": "Dining and Drinking > Restaurant > BBQ Joint",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1df931735",
+      "foursquare_category_label": "Food > BBQ Joint",
+      "is_exact": true
+    }
+  },
+  "13027": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bistro",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f1",
+      "foursquare_category_label": "Food > Bistro",
+      "is_exact": true
+    }
+  },
+  "13028": {
+    "integrated_label": "Dining and Drinking > Breakfast Spot",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d143941735",
+      "foursquare_category_label": "Food > Breakfast Spot",
+      "is_exact": true
+    }
+  },
+  "13029": {
+    "integrated_label": "Dining and Drinking > Brewery",
+    "single_match": {
+      "foursquare_category_id": "50327c8591d4c4b30a586d5d",
+      "foursquare_category_label": "Nightlife Spot > Brewery",
+      "is_exact": true
+    }
+  },
+  "13030": {
+    "integrated_label": "Dining and Drinking > Restaurant > Buffet",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f4",
+      "foursquare_category_label": "Food > Buffet",
+      "is_exact": true
+    }
+  },
+  "13031": {
+    "integrated_label": "Dining and Drinking > Restaurant > Burger Joint",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16c941735",
+      "foursquare_category_label": "Food > Burger Joint",
+      "is_exact": true
+    }
+  },
+  "13032": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06374d81259",
+      "foursquare_category_label": "Food",
+      "is_exact": false
+    }
+  },
+  "13033": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Bubble Tea Shop",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a0c",
+      "foursquare_category_label": "Food > Bubble Tea Shop",
+      "is_exact": true
+    }
+  },
+  "13034": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Café",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16d941735",
+      "foursquare_category_label": "Food > Café",
+      "is_exact": true
+    }
+  },
+  "13035": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Coffee Shop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e0931735",
+      "foursquare_category_label": "Food > Coffee Shop",
+      "is_exact": true
+    }
+  },
+  "13036": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Tea Room",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1dc931735",
+      "foursquare_category_label": "Food > Tea Room",
+      "is_exact": true
+    }
+  },
+  "13037": {
+    "integrated_label": "Dining and Drinking > Cafeteria",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d128941735",
+      "foursquare_category_label": "Food > Cafeteria",
+      "is_exact": true
+    }
+  },
+  "13038": {
+    "integrated_label": "Dining and Drinking > Cidery",
+    "single_match": {
+      "foursquare_category_id": "5e189fd6eee47d000759bbfd",
+      "foursquare_category_label": "Professional & Other Places > Cidery",
+      "is_exact": true
+    }
+  },
+  "13039": {
+    "integrated_label": "Dining and Drinking > Restaurant > Deli",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d146941735",
+      "foursquare_category_label": "Food > Deli / Bodega",
+      "is_exact": true
+    }
+  },
+  "13040": {
+    "integrated_label": "Dining and Drinking > Dessert Shop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d0941735",
+      "foursquare_category_label": "Food > Dessert Shop",
+      "is_exact": true
+    }
+  },
+  "13041": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Creperie",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f2",
+      "foursquare_category_label": "Food > Creperie",
+      "is_exact": true
+    }
+  },
+  "13042": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Cupcake Shop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1bc941735",
+      "foursquare_category_label": "Food > Dessert Shop > Cupcake Shop",
+      "is_exact": true
+    }
+  },
+  "13043": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Donut Shop",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d148941735",
+      "foursquare_category_label": "Food > Donut Shop",
+      "is_exact": true
+    }
+  },
+  "13044": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Frozen Yogurt Shop",
+    "single_match": {
+      "foursquare_category_id": "512e7cae91d4cbb4e5efe0af",
+      "foursquare_category_label": "Food > Dessert Shop > Frozen Yogurt Shop",
+      "is_exact": true
+    }
+  },
+  "13045": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Gelato Shop",
+    "single_match": {
+      "foursquare_category_id": "5f2c407c5b4c177b9a6dc536",
+      "foursquare_category_label": "Food > Dessert Shops > Gelato Shop",
+      "is_exact": true
+    }
+  },
+  "13046": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Ice Cream Parlor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c9941735",
+      "foursquare_category_label": "Food > Dessert Shop > Ice Cream Shop",
+      "is_exact": true
+    }
+  },
+  "13047": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Pastry Shop",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4e2",
+      "foursquare_category_label": "Food > Dessert Shop > Pastry Shop",
+      "is_exact": true
+    }
+  },
+  "13048": {
+    "integrated_label": "Dining and Drinking > Dessert Shop > Pie Shop",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a0a",
+      "foursquare_category_label": "Food > Dessert Shop > Pie Shop",
+      "is_exact": true
+    }
+  },
+  "13049": {
+    "integrated_label": "Dining and Drinking > Restaurant > Diner",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d147941735",
+      "foursquare_category_label": "Food > Diner",
+      "is_exact": true
+    }
+  },
+  "13050": {
+    "integrated_label": "Dining and Drinking > Distillery",
+    "single_match": {
+      "foursquare_category_id": "4e0e22f5a56208c4ea9a85a0",
+      "foursquare_category_label": "Professional & Other Places > Distillery",
+      "is_exact": true
+    }
+  },
+  "13051": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fish and Chips Shop",
+    "single_match": {
+      "foursquare_category_id": "4edd64a0c7ddd24ca188df1a",
+      "foursquare_category_label": "Food > Fish & Chips Shop",
+      "is_exact": true
+    }
+  },
+  "13052": {
+    "integrated_label": "Dining and Drinking > Food Court",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d120951735",
+      "foursquare_category_label": "Food > Food Court",
+      "is_exact": true
+    }
+  },
+  "13053": {
+    "integrated_label": "Dining and Drinking > Food Stand",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57350b",
+      "foursquare_category_label": "Food > Food Stand",
+      "is_exact": true
+    }
+  },
+  "13054": {
+    "integrated_label": "Dining and Drinking > Food Truck",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1cb941735",
+      "foursquare_category_label": "Food > Food Truck",
+      "is_exact": true
+    }
+  },
+  "13055": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fried Chicken Joint",
+    "single_match": {
+      "foursquare_category_id": "4d4ae6fc7a7b7dea34424761",
+      "foursquare_category_label": "Food > Fried Chicken Joint",
+      "is_exact": true
+    }
+  },
+  "13056": {
+    "integrated_label": "Dining and Drinking > Restaurant > Friterie",
+    "single_match": {
+      "foursquare_category_id": "55d25775498e9f6a0816a37a",
+      "foursquare_category_label": "Food > Friterie",
+      "is_exact": true
+    }
+  },
+  "13057": {
+    "integrated_label": "Dining and Drinking > Restaurant > Gastropub",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d155941735",
+      "foursquare_category_label": "Food > Gastropub",
+      "is_exact": true
+    }
+  },
+  "13058": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hot Dog Joint",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16f941735",
+      "foursquare_category_label": "Food > Hot Dog Joint",
+      "is_exact": true
+    }
+  },
+  "13059": {
+    "integrated_label": "Dining and Drinking > Juice Bar",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d112941735",
+      "foursquare_category_label": "Food > Juice Bar",
+      "is_exact": true
+    }
+  },
+  "13060": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mac and Cheese Joint",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1bf941735",
+      "foursquare_category_label": "Food > Mac & Cheese Joint",
+      "is_exact": true
+    }
+  },
+  "13061": {
+    "integrated_label": "Dining and Drinking > Meadery",
+    "single_match": {
+      "foursquare_category_id": "5e189d71eee47d000759b7e2",
+      "foursquare_category_label": "Professional & Other Places > Meadery",
+      "is_exact": true
+    }
+  },
+  "13062": {
+    "integrated_label": "Dining and Drinking > Night Market",
+    "single_match": {
+      "foursquare_category_id": "53e510b7498ebcb1801b55d4",
+      "foursquare_category_label": "Nightlife Spot > Night Market",
+      "is_exact": true
+    }
+  },
+  "13063": {
+    "integrated_label": "Dining and Drinking > Cafes, Coffee, and Tea Houses > Pet Café",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573508",
+      "foursquare_category_label": "Food > Pet Café",
+      "is_exact": true
+    }
+  },
+  "13064": {
+    "integrated_label": "Dining and Drinking > Restaurant > Pizzeria",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ca941735",
+      "foursquare_category_label": "Food > Pizza Place",
+      "is_exact": true
+    }
+  },
+  "13065": {
+    "integrated_label": "Dining and Drinking > Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06374d81259",
+      "foursquare_category_label": "Food",
+      "is_exact": false
+    }
+  },
+  "13066": {
+    "integrated_label": "Dining and Drinking > Restaurant > Afghan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "503288ae91d4c4b30a586d67",
+      "foursquare_category_label": "Food > Afghan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13067": {
+    "integrated_label": "Dining and Drinking > Restaurant > African Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c8941735",
+      "foursquare_category_label": "Food > African Restaurant",
+      "is_exact": true
+    }
+  },
+  "13068": {
+    "integrated_label": "Dining and Drinking > Restaurant > American Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14e941735",
+      "foursquare_category_label": "Food > American Restaurant",
+      "is_exact": true
+    }
+  },
+  "13069": {
+    "integrated_label": "Dining and Drinking > Restaurant > Arepa Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d152941735",
+      "foursquare_category_label": "Food > Latin American Restaurant > Arepa Restaurant",
+      "is_exact": true
+    }
+  },
+  "13070": {
+    "integrated_label": "Dining and Drinking > Restaurant > Argentinian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d107941735",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Argentinian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13071": {
+    "integrated_label": "Dining and Drinking > Restaurant > Armenian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c2b7db6d05514c7044837",
+      "foursquare_category_label": "Food > Armenian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13072": {
+    "integrated_label": "Dining and Drinking > Restaurant > Asian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d142941735",
+      "foursquare_category_label": "Food > Asian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13073": {
+    "integrated_label": "Dining and Drinking > Restaurant > Australian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d169941735",
+      "foursquare_category_label": "Food > Australian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13074": {
+    "integrated_label": "Dining and Drinking > Restaurant > Austrian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a01",
+      "foursquare_category_label": "Food > Austrian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13075": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bangladeshi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5e179ee74ae8e90006e9a746",
+      "foursquare_category_label": "Food > Bangladeshi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13076": {
+    "integrated_label": "Dining and Drinking > Restaurant > Belarusian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e97",
+      "foursquare_category_label": "Food > Eastern European Restaurant > Belarusian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13077": {
+    "integrated_label": "Dining and Drinking > Restaurant > Belgian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a02",
+      "foursquare_category_label": "Food > Belgian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13078": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bosnian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1ee",
+      "foursquare_category_label": "Food > Eastern European Restaurant > Bosnian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13079": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16b941735",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13080": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Acai House",
+    "single_match": {
+      "foursquare_category_id": "5294c7523cf9994f4e043a62",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Acai House",
+      "is_exact": true
+    }
+  },
+  "13081": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Baiano Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939ae13cf9994f4e043a3b",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Baiano Restaurant",
+      "is_exact": true
+    }
+  },
+  "13082": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Central Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939a9e3cf9994f4e043a36",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Central Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13083": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Churrascaria",
+    "single_match": {
+      "foursquare_category_id": "52939a643cf9994f4e043a33",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Churrascaria",
+      "is_exact": true
+    }
+  },
+  "13084": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Empada House",
+    "single_match": {
+      "foursquare_category_id": "5294c55c3cf9994f4e043a61",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Empada House",
+      "is_exact": true
+    }
+  },
+  "13085": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Goiano Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939af83cf9994f4e043a3d",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Goiano Restaurant",
+      "is_exact": true
+    }
+  },
+  "13086": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Mineiro Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939aed3cf9994f4e043a3c",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Mineiro Restaurant",
+      "is_exact": true
+    }
+  },
+  "13087": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Northeastern Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939aae3cf9994f4e043a37",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Northeastern Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13088": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Northern Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939ab93cf9994f4e043a38",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Northern Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13089": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Pastelaria",
+    "single_match": {
+      "foursquare_category_id": "5294cbda3cf9994f4e043a63",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Pastelaria",
+      "is_exact": true
+    }
+  },
+  "13090": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Southeastern Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939ac53cf9994f4e043a39",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Southeastern Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13091": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Southern Brazilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939ad03cf9994f4e043a3a",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Southern Brazilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13092": {
+    "integrated_label": "Dining and Drinking > Restaurant > Brazilian Restaurant > Tapiocaria",
+    "single_match": {
+      "foursquare_category_id": "52939a7d3cf9994f4e043a34",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Brazilian Restaurant > Tapiocaria",
+      "is_exact": true
+    }
+  },
+  "13093": {
+    "integrated_label": "Dining and Drinking > Restaurant > Bulgarian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734f3",
+      "foursquare_category_label": "Food > Eastern European Restaurant > Bulgarian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13094": {
+    "integrated_label": "Dining and Drinking > Restaurant > Burmese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573568",
+      "foursquare_category_label": "Food > Asian Restaurant > Burmese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13095": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cajun / Creole Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d17a941735",
+      "foursquare_category_label": "Food > Cajun / Creole Restaurant",
+      "is_exact": true
+    }
+  },
+  "13096": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cambodian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a03",
+      "foursquare_category_label": "Food > Asian Restaurant > Cambodian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13097": {
+    "integrated_label": "Dining and Drinking > Restaurant > Caribbean Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d144941735",
+      "foursquare_category_label": "Food > Caribbean Restaurant",
+      "is_exact": true
+    }
+  },
+  "13098": {
+    "integrated_label": "Dining and Drinking > Restaurant > Caucasian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5293a7d53cf9994f4e043a45",
+      "foursquare_category_label": "Food > Caucasian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13099": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d145941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13100": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Anhui Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a5e3cf9994f4e043bea",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Anhui Restaurant",
+      "is_exact": true
+    }
+  },
+  "13101": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Beijing Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a723cf9994f4e043bec",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Beijing Restaurant",
+      "is_exact": true
+    }
+  },
+  "13102": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Cantonese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a7c3cf9994f4e043bed",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Cantonese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13103": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Cha Chaan Teng",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1d3",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Cha Chaan Teng",
+      "is_exact": true
+    }
+  },
+  "13104": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Chinese Aristocrat Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a673cf9994f4e043beb",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Chinese Aristocrat Restaurant",
+      "is_exact": true
+    }
+  },
+  "13105": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Chinese Breakfast Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a903cf9994f4e043bee",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Chinese Breakfast Place",
+      "is_exact": true
+    }
+  },
+  "13106": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Dim Sum Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f5931735",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Dim Sum Restaurant",
+      "is_exact": true
+    }
+  },
+  "13107": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Dongbei Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3a9f3cf9994f4e043bef",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Dongbei Restaurant",
+      "is_exact": true
+    }
+  },
+  "13108": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Fujian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3aaa3cf9994f4e043bf0",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Fujian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13109": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Guizhou Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3ab53cf9994f4e043bf1",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Guizhou Restaurant",
+      "is_exact": true
+    }
+  },
+  "13110": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hainan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3abe3cf9994f4e043bf2",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Hainan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13111": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hakka Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3ac83cf9994f4e043bf3",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Hakka Restaurant",
+      "is_exact": true
+    }
+  },
+  "13112": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Henan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3ad23cf9994f4e043bf4",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Henan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13113": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hong Kong Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3add3cf9994f4e043bf5",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Hong Kong Restaurant",
+      "is_exact": true
+    }
+  },
+  "13114": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Huaiyang Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3af23cf9994f4e043bf7",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Huaiyang Restaurant",
+      "is_exact": true
+    }
+  },
+  "13115": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hubei Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3ae63cf9994f4e043bf6",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Hubei Restaurant",
+      "is_exact": true
+    }
+  },
+  "13116": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Hunan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3afc3cf9994f4e043bf8",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Hunan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13117": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Imperial Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b053cf9994f4e043bf9",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Imperial Restaurant",
+      "is_exact": true
+    }
+  },
+  "13118": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Jiangsu Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b213cf9994f4e043bfa",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Jiangsu Restaurant",
+      "is_exact": true
+    }
+  },
+  "13119": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Jiangxi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b293cf9994f4e043bfb",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Jiangxi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13120": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Macanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b343cf9994f4e043bfc",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Macanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13121": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Manchu Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b3b3cf9994f4e043bfd",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Manchu Restaurant",
+      "is_exact": true
+    }
+  },
+  "13122": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Peking Duck Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b463cf9994f4e043bfe",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Peking Duck Restaurant",
+      "is_exact": true
+    }
+  },
+  "13123": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shaanxi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b633cf9994f4e043c01",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Shaanxi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13124": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shandong Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b513cf9994f4e043bff",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Shandong Restaurant",
+      "is_exact": true
+    }
+  },
+  "13125": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shanghai Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b593cf9994f4e043c00",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Shanghai Restaurant",
+      "is_exact": true
+    }
+  },
+  "13126": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Shanxi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b6e3cf9994f4e043c02",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Shanxi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13127": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Szechuan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b773cf9994f4e043c03",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Szechuan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13128": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Taiwanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b813cf9994f4e043c04",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Taiwanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13129": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Tianjin Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b893cf9994f4e043c05",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Tianjin Restaurant",
+      "is_exact": true
+    }
+  },
+  "13130": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Xinjiang Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b913cf9994f4e043c06",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Xinjiang Restaurant",
+      "is_exact": true
+    }
+  },
+  "13131": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Yunnan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3b9a3cf9994f4e043c07",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Yunnan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13132": {
+    "integrated_label": "Dining and Drinking > Restaurant > Chinese Restaurant > Zhejiang Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af3ba23cf9994f4e043c08",
+      "foursquare_category_label": "Food > Asian Restaurant > Chinese Restaurant > Zhejiang Restaurant",
+      "is_exact": true
+    }
+  },
+  "13133": {
+    "integrated_label": "Dining and Drinking > Restaurant > Colombian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1f4",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Colombian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13134": {
+    "integrated_label": "Dining and Drinking > Restaurant > Comfort Food Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a00",
+      "foursquare_category_label": "Food > Comfort Food Restaurant",
+      "is_exact": true
+    }
+  },
+  "13135": {
+    "integrated_label": "Dining and Drinking > Restaurant > Cuban Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d154941735",
+      "foursquare_category_label": "Food > Caribbean Restaurant > Cuban Restaurant",
+      "is_exact": true
+    }
+  },
+  "13136": {
+    "integrated_label": "Dining and Drinking > Restaurant > Czech Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52f2ae52bcbc57f1066b8b81",
+      "foursquare_category_label": "Food > Czech Restaurant",
+      "is_exact": true
+    }
+  },
+  "13137": {
+    "integrated_label": "Dining and Drinking > Restaurant > Dumpling Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d108941735",
+      "foursquare_category_label": "Food > Dumpling Restaurant",
+      "is_exact": true
+    }
+  },
+  "13138": {
+    "integrated_label": "Dining and Drinking > Restaurant > Dutch Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4d0",
+      "foursquare_category_label": "Food > Dutch Restaurant",
+      "is_exact": true
+    }
+  },
+  "13139": {
+    "integrated_label": "Dining and Drinking > Restaurant > Eastern European Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d109941735",
+      "foursquare_category_label": "Food > Eastern European Restaurant",
+      "is_exact": true
+    }
+  },
+  "13140": {
+    "integrated_label": "Dining and Drinking > Restaurant > Egyptian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89e1",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Egyptian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13141": {
+    "integrated_label": "Dining and Drinking > Restaurant > Empanada Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52939a8c3cf9994f4e043a35",
+      "foursquare_category_label": "Food > Latin American Restaurant > Empanada Restaurant",
+      "is_exact": true
+    }
+  },
+  "13142": {
+    "integrated_label": "Dining and Drinking > Restaurant > English Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a05",
+      "foursquare_category_label": "Food > English Restaurant",
+      "is_exact": true
+    }
+  },
+  "13143": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ethiopian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10a941735",
+      "foursquare_category_label": "Food > African Restaurant > Ethiopian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13144": {
+    "integrated_label": "Dining and Drinking > Restaurant > Falafel Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10b941735",
+      "foursquare_category_label": "Food > Falafel Restaurant",
+      "is_exact": true
+    }
+  },
+  "13145": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fast Food Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d16e941735",
+      "foursquare_category_label": "Food > Fast Food Restaurant",
+      "is_exact": true
+    }
+  },
+  "13146": {
+    "integrated_label": "Dining and Drinking > Restaurant > Filipino Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4eb1bd1c3b7b55596b4a748f",
+      "foursquare_category_label": "Food > Asian Restaurant > Filipino Restaurant",
+      "is_exact": true
+    }
+  },
+  "13147": {
+    "integrated_label": "Dining and Drinking > Restaurant > Fondue Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a09",
+      "foursquare_category_label": "Food > Fondue Restaurant",
+      "is_exact": true
+    }
+  },
+  "13148": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10c941735",
+      "foursquare_category_label": "Food > French Restaurant",
+      "is_exact": true
+    }
+  },
+  "13149": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Alsatian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306b6",
+      "foursquare_category_label": "Food > French Restaurant > Alsatian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13150": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Auvergne Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306b8",
+      "foursquare_category_label": "Food > French Restaurant > Auvergne Restaurant",
+      "is_exact": true
+    }
+  },
+  "13151": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Basque Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306bc",
+      "foursquare_category_label": "Food > French Restaurant > Basque Restaurant",
+      "is_exact": true
+    }
+  },
+  "13152": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Brasserie",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306b0",
+      "foursquare_category_label": "Food > French Restaurant > Brasserie",
+      "is_exact": true
+    }
+  },
+  "13153": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Breton Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306c5",
+      "foursquare_category_label": "Food > French Restaurant > Breton Restaurant",
+      "is_exact": true
+    }
+  },
+  "13154": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Burgundian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306c0",
+      "foursquare_category_label": "Food > French Restaurant > Burgundian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13155": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Catalan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306cb",
+      "foursquare_category_label": "Food > French Restaurant > Catalan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13156": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Ch'ti Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306ce",
+      "foursquare_category_label": "Food > French Restaurant > Ch'ti Restaurant",
+      "is_exact": true
+    }
+  },
+  "13157": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Corsican Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306d1",
+      "foursquare_category_label": "Food > French Restaurant > Corsican Restaurant",
+      "is_exact": true
+    }
+  },
+  "13158": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Estaminet",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306b4",
+      "foursquare_category_label": "Food > French Restaurant > Estaminet",
+      "is_exact": true
+    }
+  },
+  "13159": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Labour Canteen",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306b2",
+      "foursquare_category_label": "Food > French Restaurant > Labour Canteen",
+      "is_exact": true
+    }
+  },
+  "13160": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Lyonese Bouchon",
+    "single_match": {
+      "foursquare_category_id": "57558b35e4b065ecebd306ad",
+      "foursquare_category_label": "Food > French Restaurant > Lyonese Bouchon",
+      "is_exact": true
+    }
+  },
+  "13161": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Norman Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306d4",
+      "foursquare_category_label": "Food > French Restaurant > Norman Restaurant",
+      "is_exact": true
+    }
+  },
+  "13162": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Provençal Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306d7",
+      "foursquare_category_label": "Food > French Restaurant > Provençal Restaurant",
+      "is_exact": true
+    }
+  },
+  "13163": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Savoyard Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306da",
+      "foursquare_category_label": "Food > French Restaurant > Savoyard Restaurant",
+      "is_exact": true
+    }
+  },
+  "13164": {
+    "integrated_label": "Dining and Drinking > Restaurant > French Restaurant > Southwestern French Restaurant",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306ba",
+      "foursquare_category_label": "Food > French Restaurant > Southwestern French Restaurant",
+      "is_exact": true
+    }
+  },
+  "13165": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10d941735",
+      "foursquare_category_label": "Food > German Restaurant",
+      "is_exact": true
+    }
+  },
+  "13166": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Apple Wine Pub",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573583",
+      "foursquare_category_label": "Food > German Restaurant > Apple Wine Pub",
+      "is_exact": true
+    }
+  },
+  "13167": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Bavarian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573572",
+      "foursquare_category_label": "Food > German Restaurant > Bavarian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13168": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Bratwurst Joint",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57358e",
+      "foursquare_category_label": "Food > German Restaurant > Bratwurst Joint",
+      "is_exact": true
+    }
+  },
+  "13169": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Currywurst Joint",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57358b",
+      "foursquare_category_label": "Food > German Restaurant > Currywurst Joint",
+      "is_exact": true
+    }
+  },
+  "13170": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Franconian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573574",
+      "foursquare_category_label": "Food > German Restaurant > Franconian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13171": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > German Pop-Up Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573592",
+      "foursquare_category_label": "Food > German Restaurant > German Pop-Up Restaurant",
+      "is_exact": true
+    }
+  },
+  "13172": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Palatine Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573578",
+      "foursquare_category_label": "Food > German Restaurant > Palatine Restaurant",
+      "is_exact": true
+    }
+  },
+  "13173": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Rhenisch Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57357b",
+      "foursquare_category_label": "Food > German Restaurant > Rhenisch Restaurant",
+      "is_exact": true
+    }
+  },
+  "13174": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Schnitzel Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573587",
+      "foursquare_category_label": "Food > German Restaurant > Schnitzel Restaurant",
+      "is_exact": true
+    }
+  },
+  "13175": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Silesian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57357f",
+      "foursquare_category_label": "Food > German Restaurant > Silesian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13176": {
+    "integrated_label": "Dining and Drinking > Restaurant > German Restaurant > Swabian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d573576",
+      "foursquare_category_label": "Food > German Restaurant > Swabian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13177": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10e941735",
+      "foursquare_category_label": "Food > Greek Restaurant",
+      "is_exact": true
+    }
+  },
+  "13178": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Bougatsa Shop",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83e8",
+      "foursquare_category_label": "Food > Greek Restaurant > Bougatsa Shop",
+      "is_exact": true
+    }
+  },
+  "13179": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Cretan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83e2",
+      "foursquare_category_label": "Food > Greek Restaurant > Cretan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13180": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Fish Taverna",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83d8",
+      "foursquare_category_label": "Food > Greek Restaurant > Fish Taverna",
+      "is_exact": true
+    }
+  },
+  "13181": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Grilled Meat Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83d6",
+      "foursquare_category_label": "Food > Greek Restaurant > Grilled Meat Restaurant",
+      "is_exact": true
+    }
+  },
+  "13182": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Kafenio",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83e6",
+      "foursquare_category_label": "Food > Greek Restaurant > Kafenio",
+      "is_exact": true
+    }
+  },
+  "13183": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Magirio",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83e4",
+      "foursquare_category_label": "Food > Greek Restaurant > Magirio",
+      "is_exact": true
+    }
+  },
+  "13184": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Meze Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83da",
+      "foursquare_category_label": "Food > Greek Restaurant > Meze Restaurant",
+      "is_exact": true
+    }
+  },
+  "13185": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Modern Greek Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83d4",
+      "foursquare_category_label": "Food > Greek Restaurant > Modern Greek Restaurant",
+      "is_exact": true
+    }
+  },
+  "13186": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Ouzeri",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83dc",
+      "foursquare_category_label": "Food > Greek Restaurant > Ouzeri",
+      "is_exact": true
+    }
+  },
+  "13187": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Patsa Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83e0",
+      "foursquare_category_label": "Food > Greek Restaurant > Patsa Restaurant",
+      "is_exact": true
+    }
+  },
+  "13188": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Souvlaki Shop",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f3",
+      "foursquare_category_label": "Food > Greek Restaurant > Souvlaki Shop",
+      "is_exact": true
+    }
+  },
+  "13189": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Taverna",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83d2",
+      "foursquare_category_label": "Food > Greek Restaurant > Taverna",
+      "is_exact": true
+    }
+  },
+  "13190": {
+    "integrated_label": "Dining and Drinking > Restaurant > Greek Restaurant > Tsipouro Restaurant",
+    "single_match": {
+      "foursquare_category_id": "53d6c1b0e4b02351e88a83de",
+      "foursquare_category_label": "Food > Greek Restaurant > Tsipouro Restaurant",
+      "is_exact": true
+    }
+  },
+  "13191": {
+    "integrated_label": "Dining and Drinking > Restaurant > Halal Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79ff",
+      "foursquare_category_label": "Food > Halal Restaurant",
+      "is_exact": true
+    }
+  },
+  "13192": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hawaiian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79fe",
+      "foursquare_category_label": "Food > Hawaiian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13193": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hawaiian Restaurant > Poke Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89d4",
+      "foursquare_category_label": "Food > Hawaiian Restaurant > Poke Place",
+      "is_exact": true
+    }
+  },
+  "13194": {
+    "integrated_label": "Dining and Drinking > Restaurant > Himalayan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79fb",
+      "foursquare_category_label": "Food > Asian Restaurant > Himalayan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13195": {
+    "integrated_label": "Dining and Drinking > Restaurant > Honduran Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c32587ff30c0d7ac09638",
+      "foursquare_category_label": "Food > Latin American Restaurant > Honduran Restaurant",
+      "is_exact": true
+    }
+  },
+  "13196": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hotpot Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af0bd33cf9994f4e043bdd",
+      "foursquare_category_label": "Food > Asian Restaurant > Hotpot Restaurant",
+      "is_exact": true
+    }
+  },
+  "13197": {
+    "integrated_label": "Dining and Drinking > Restaurant > Hungarian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79fa",
+      "foursquare_category_label": "Food > Hungarian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13198": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Chinese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfdf",
+      "foursquare_category_label": "Food > Indian Restaurant > Indian Chinese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13199": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10f941735",
+      "foursquare_category_label": "Food > Indian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13200": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Andhra Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe5",
+      "foursquare_category_label": "Food > Indian Restaurant > Andhra Restaurant",
+      "is_exact": true
+    }
+  },
+  "13201": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Awadhi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff3",
+      "foursquare_category_label": "Food > Indian Restaurant > Awadhi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13202": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Bengali Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff5",
+      "foursquare_category_label": "Food > Indian Restaurant > Bengali Restaurant",
+      "is_exact": true
+    }
+  },
+  "13203": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Chaat Place",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe2",
+      "foursquare_category_label": "Food > Indian Restaurant > Chaat Place",
+      "is_exact": true
+    }
+  },
+  "13204": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Chettinad Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff2",
+      "foursquare_category_label": "Food > Indian Restaurant > Chettinad Restaurant",
+      "is_exact": true
+    }
+  },
+  "13205": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Dhaba",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe1",
+      "foursquare_category_label": "Food > Indian Restaurant > Dhaba",
+      "is_exact": true
+    }
+  },
+  "13206": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Dosa Place",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe3",
+      "foursquare_category_label": "Food > Indian Restaurant > Dosa Place",
+      "is_exact": true
+    }
+  },
+  "13207": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Goan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe8",
+      "foursquare_category_label": "Food > Indian Restaurant > Goan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13208": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Gujarati Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe9",
+      "foursquare_category_label": "Food > Indian Restaurant > Gujarati Restaurant",
+      "is_exact": true
+    }
+  },
+  "13209": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Hyderabadi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe6",
+      "foursquare_category_label": "Food > Indian Restaurant > Hyderabadi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13210": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Indian Sweet Shop",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe4",
+      "foursquare_category_label": "Food > Indian Restaurant > Indian Sweet Shop",
+      "is_exact": true
+    }
+  },
+  "13211": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Irani Cafe",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe7",
+      "foursquare_category_label": "Food > Indian Restaurant > Irani Cafe",
+      "is_exact": true
+    }
+  },
+  "13212": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Jain Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfea",
+      "foursquare_category_label": "Food > Indian Restaurant > Jain Restaurant",
+      "is_exact": true
+    }
+  },
+  "13213": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Karnataka Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfeb",
+      "foursquare_category_label": "Food > Indian Restaurant > Karnataka Restaurant",
+      "is_exact": true
+    }
+  },
+  "13214": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Kerala Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfed",
+      "foursquare_category_label": "Food > Indian Restaurant > Kerala Restaurant",
+      "is_exact": true
+    }
+  },
+  "13215": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Maharashtrian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfee",
+      "foursquare_category_label": "Food > Indian Restaurant > Maharashtrian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13216": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Mughlai Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff4",
+      "foursquare_category_label": "Food > Indian Restaurant > Mughlai Restaurant",
+      "is_exact": true
+    }
+  },
+  "13217": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Multicuisine Indian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfe0",
+      "foursquare_category_label": "Food > Indian Restaurant > Multicuisine Indian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13218": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > North Indian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfdd",
+      "foursquare_category_label": "Food > Indian Restaurant > North Indian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13219": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Northeast Indian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff6",
+      "foursquare_category_label": "Food > Indian Restaurant > Northeast Indian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13220": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Parsi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfef",
+      "foursquare_category_label": "Food > Indian Restaurant > Parsi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13221": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Punjabi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff0",
+      "foursquare_category_label": "Food > Indian Restaurant > Punjabi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13222": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Rajasthani Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dff1",
+      "foursquare_category_label": "Food > Indian Restaurant > Rajasthani Restaurant",
+      "is_exact": true
+    }
+  },
+  "13223": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > South Indian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfde",
+      "foursquare_category_label": "Food > Indian Restaurant > South Indian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13224": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indian Restaurant > Udupi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "54135bf5e4b08f3d2429dfec",
+      "foursquare_category_label": "Food > Indian Restaurant > Udupi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13225": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4deefc054765f83613cdba6f",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13226": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Acehnese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043ac9",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Acehnese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13227": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Balinese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043acb",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Balinese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13228": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Betawinese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043aca",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Betawinese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13229": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Indonesian Meatball Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043acc",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Indonesian Meatball Place",
+      "is_exact": true
+    }
+  },
+  "13230": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Javanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043ac7",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Javanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13231": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Manadonese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043ac8",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Manadonese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13232": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Padangnese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043ac5",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Padangnese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13233": {
+    "integrated_label": "Dining and Drinking > Restaurant > Indonesian Restaurant > Sundanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960eda3cf9994f4e043ac6",
+      "foursquare_category_label": "Food > Asian Restaurant > Indonesian Restaurant > Sundanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13234": {
+    "integrated_label": "Dining and Drinking > Restaurant > Iraqi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89e7",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Iraqi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13235": {
+    "integrated_label": "Dining and Drinking > Restaurant > Israeli Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573529",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Israeli Restaurant",
+      "is_exact": true
+    }
+  },
+  "13236": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d110941735",
+      "foursquare_category_label": "Food > Italian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13237": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Abruzzo Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbb6",
+      "foursquare_category_label": "Food > Italian Restaurant > Abruzzo Restaurant",
+      "is_exact": true
+    }
+  },
+  "13238": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Agriturismo",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb7c",
+      "foursquare_category_label": "Food > Italian Restaurant > Agriturismo",
+      "is_exact": true
+    }
+  },
+  "13239": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Aosta Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cba7",
+      "foursquare_category_label": "Food > Italian Restaurant > Aosta Restaurant",
+      "is_exact": true
+    }
+  },
+  "13240": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Basilicata Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cba1",
+      "foursquare_category_label": "Food > Italian Restaurant > Basilicata Restaurant",
+      "is_exact": true
+    }
+  },
+  "13241": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Calabria Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cba4",
+      "foursquare_category_label": "Food > Italian Restaurant > Calabria Restaurant",
+      "is_exact": true
+    }
+  },
+  "13242": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Campanian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb95",
+      "foursquare_category_label": "Food > Italian Restaurant > Campanian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13243": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Emilia Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb89",
+      "foursquare_category_label": "Food > Italian Restaurant > Emilia Restaurant",
+      "is_exact": true
+    }
+  },
+  "13244": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Friuli Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb9b",
+      "foursquare_category_label": "Food > Italian Restaurant > Friuli Restaurant",
+      "is_exact": true
+    }
+  },
+  "13245": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Ligurian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb98",
+      "foursquare_category_label": "Food > Italian Restaurant > Ligurian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13246": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Lombard Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbbf",
+      "foursquare_category_label": "Food > Italian Restaurant > Lombard Restaurant",
+      "is_exact": true
+    }
+  },
+  "13247": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Malga",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb79",
+      "foursquare_category_label": "Food > Italian Restaurant > Malga",
+      "is_exact": true
+    }
+  },
+  "13248": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Marche Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbb0",
+      "foursquare_category_label": "Food > Italian Restaurant > Marche Restaurant",
+      "is_exact": true
+    }
+  },
+  "13249": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Molise Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbb3",
+      "foursquare_category_label": "Food > Italian Restaurant > Molise Restaurant",
+      "is_exact": true
+    }
+  },
+  "13250": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Piadineria",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb74",
+      "foursquare_category_label": "Food > Italian Restaurant > Piadineria",
+      "is_exact": true
+    }
+  },
+  "13251": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Piedmontese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbaa",
+      "foursquare_category_label": "Food > Italian Restaurant > Piedmontese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13252": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Puglia Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb83",
+      "foursquare_category_label": "Food > Italian Restaurant > Puglia Restaurant",
+      "is_exact": true
+    }
+  },
+  "13253": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Romagna Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb8c",
+      "foursquare_category_label": "Food > Italian Restaurant > Romagna Restaurant",
+      "is_exact": true
+    }
+  },
+  "13254": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Roman Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb92",
+      "foursquare_category_label": "Food > Italian Restaurant > Roman Restaurant",
+      "is_exact": true
+    }
+  },
+  "13255": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Sardinian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb8f",
+      "foursquare_category_label": "Food > Italian Restaurant > Sardinian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13256": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Sicilian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb86",
+      "foursquare_category_label": "Food > Italian Restaurant > Sicilian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13257": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > South Tyrolean Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbb9",
+      "foursquare_category_label": "Food > Italian Restaurant > South Tyrolean Restaurant",
+      "is_exact": true
+    }
+  },
+  "13258": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Trattoria/Osteria",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb7f",
+      "foursquare_category_label": "Food > Italian Restaurant > Trattoria/Osteria",
+      "is_exact": true
+    }
+  },
+  "13259": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Trentino Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbbc",
+      "foursquare_category_label": "Food > Italian Restaurant > Trentino Restaurant",
+      "is_exact": true
+    }
+  },
+  "13260": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Tuscan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cb9e",
+      "foursquare_category_label": "Food > Italian Restaurant > Tuscan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13261": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Umbrian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbc2",
+      "foursquare_category_label": "Food > Italian Restaurant > Umbrian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13262": {
+    "integrated_label": "Dining and Drinking > Restaurant > Italian Restaurant > Veneto Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a5a1ebe4b013909087cbad",
+      "foursquare_category_label": "Food > Italian Restaurant > Veneto Restaurant",
+      "is_exact": true
+    }
+  },
+  "13263": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d111941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13264": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Donburi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb0c",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Donburi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13265": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Japanese Curry Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb30",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Japanese Curry Restaurant",
+      "is_exact": true
+    }
+  },
+  "13266": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Japanese Family Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c2436b6d05514c704433e",
+      "foursquare_category_label": "Food > Asian Restaurants > Japanese Restaurants > Japanese Family Restaurant",
+      "is_exact": true
+    }
+  },
+  "13267": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Kaiseki Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb21",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Kaiseki Restaurant",
+      "is_exact": true
+    }
+  },
+  "13268": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Kushikatsu Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb06",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Kushikatsu Restaurant",
+      "is_exact": true
+    }
+  },
+  "13269": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Monjayaki Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb1b",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Monjayaki Restaurant",
+      "is_exact": true
+    }
+  },
+  "13270": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Nabe Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb1e",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Nabe Restaurant",
+      "is_exact": true
+    }
+  },
+  "13271": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Okonomiyaki Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb18",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Okonomiyaki Restaurant",
+      "is_exact": true
+    }
+  },
+  "13272": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Ramen Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb24",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Ramen Restaurant",
+      "is_exact": true
+    }
+  },
+  "13273": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Shabu-Shabu Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb15",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Shabu-Shabu Restaurant",
+      "is_exact": true
+    }
+  },
+  "13274": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Soba Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb27",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Soba Restaurant",
+      "is_exact": true
+    }
+  },
+  "13275": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Sukiyaki Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb12",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Sukiyaki Restaurant",
+      "is_exact": true
+    }
+  },
+  "13276": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Sushi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d2941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Sushi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13277": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Takoyaki Place",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb2d",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Takoyaki Place",
+      "is_exact": true
+    }
+  },
+  "13278": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Teishoku Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c239eb6d05514c70441ee",
+      "foursquare_category_label": "Food > Asian Restaurants > Japanese Restaurants > Teishoku Restaurant",
+      "is_exact": true
+    }
+  },
+  "13279": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Tempura Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59a31e4b013909087cb00",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Tempura Restaurant",
+      "is_exact": true
+    }
+  },
+  "13280": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Tonkatsu Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59af1e4b013909087cb03",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Tonkatsu Restaurant",
+      "is_exact": true
+    }
+  },
+  "13281": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Udon Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb2a",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Udon Restaurant",
+      "is_exact": true
+    }
+  },
+  "13282": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Unagi Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb0f",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Unagi Restaurant",
+      "is_exact": true
+    }
+  },
+  "13283": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Wagashi Place",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb33",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Wagashi Place",
+      "is_exact": true
+    }
+  },
+  "13284": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Yakitori Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb09",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Yakitori Restaurant",
+      "is_exact": true
+    }
+  },
+  "13285": {
+    "integrated_label": "Dining and Drinking > Restaurant > Japanese Restaurant > Yoshoku Restaurant",
+    "single_match": {
+      "foursquare_category_id": "55a59bace4b013909087cb36",
+      "foursquare_category_label": "Food > Asian Restaurant > Japanese Restaurant > Yoshoku Restaurant",
+      "is_exact": true
+    }
+  },
+  "13286": {
+    "integrated_label": "Dining and Drinking > Restaurant > Jewish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79fd",
+      "foursquare_category_label": "Food > Jewish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13287": {
+    "integrated_label": "Dining and Drinking > Restaurant > Jewish Restaurant > Kosher Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79fc",
+      "foursquare_category_label": "Food > Jewish Restaurant > Kosher Restaurant",
+      "is_exact": true
+    }
+  },
+  "13288": {
+    "integrated_label": "Dining and Drinking > Restaurant > Kebab Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d7",
+      "foursquare_category_label": "Food > Kebab Restaurant",
+      "is_exact": true
+    }
+  },
+  "13289": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d113941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant",
+      "is_exact": true
+    }
+  },
+  "13290": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Bossam/Jokbal Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734e4",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant > Bossam/Jokbal Restaurant",
+      "is_exact": true
+    }
+  },
+  "13291": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Bunsik Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734f0",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant > Bunsik Restaurant",
+      "is_exact": true
+    }
+  },
+  "13292": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Gukbap Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734e7",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant > Gukbap Restaurant",
+      "is_exact": true
+    }
+  },
+  "13293": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Janguh Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734ed",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant > Janguh Restaurant",
+      "is_exact": true
+    }
+  },
+  "13294": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Korean BBQ Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c3f6b5b4c177b9a6dc388",
+      "foursquare_category_label": "Food > Asian Restaurants > Korean Restaurants > Korean BBQ Restaurant",
+      "is_exact": true
+    }
+  },
+  "13295": {
+    "integrated_label": "Dining and Drinking > Restaurant > Korean Restaurant > Samgyetang Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734ea",
+      "foursquare_category_label": "Food > Asian Restaurant > Korean Restaurant > Samgyetang Restaurant",
+      "is_exact": true
+    }
+  },
+  "13296": {
+    "integrated_label": "Dining and Drinking > Restaurant > Kurdish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4ca",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Kurdish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13297": {
+    "integrated_label": "Dining and Drinking > Restaurant > Latin American Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1be941735",
+      "foursquare_category_label": "Food > Latin American Restaurant",
+      "is_exact": true
+    }
+  },
+  "13298": {
+    "integrated_label": "Dining and Drinking > Restaurant > Lebanese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1cd",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Lebanese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13299": {
+    "integrated_label": "Dining and Drinking > Restaurant > Malay Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d156941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Malay Restaurant",
+      "is_exact": true
+    }
+  },
+  "13300": {
+    "integrated_label": "Dining and Drinking > Restaurant > Malay Restaurant > Mamak Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5ae9595eb77c77002c2f9f26",
+      "foursquare_category_label": "Food > Asian Restaurant > Malay Restaurant > Mamak Restaurant",
+      "is_exact": true
+    }
+  },
+  "13301": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mauritian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c344a5b4c177b9a6dc011",
+      "foursquare_category_label": "Food > Asian Restaurants > Mauritian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13302": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mediterranean Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c0941735",
+      "foursquare_category_label": "Food > Mediterranean Restaurant",
+      "is_exact": true
+    }
+  },
+  "13303": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c1941735",
+      "foursquare_category_label": "Food > Mexican Restaurant",
+      "is_exact": true
+    }
+  },
+  "13304": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Botanero",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1d9",
+      "foursquare_category_label": "Food > Mexican Restaurant > Botanero",
+      "is_exact": true
+    }
+  },
+  "13305": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Burrito Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d153941735",
+      "foursquare_category_label": "Food > Mexican Restaurant > Burrito Place",
+      "is_exact": true
+    }
+  },
+  "13306": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Taco Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d151941735",
+      "foursquare_category_label": "Food > Mexican Restaurant > Taco Place",
+      "is_exact": true
+    }
+  },
+  "13307": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Tex-Mex Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371ae4b08b9a8d5734ba",
+      "foursquare_category_label": "Food > Mexican Restaurant > Tex-Mex Restaurant",
+      "is_exact": true
+    }
+  },
+  "13308": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mexican Restaurant > Yucatecan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4d3",
+      "foursquare_category_label": "Food > Mexican Restaurant > Yucatecan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13309": {
+    "integrated_label": "Dining and Drinking > Restaurant > Middle Eastern Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d115941735",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant",
+      "is_exact": true
+    }
+  },
+  "13310": {
+    "integrated_label": "Dining and Drinking > Restaurant > Modern European Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f9",
+      "foursquare_category_label": "Food > Modern European Restaurant",
+      "is_exact": true
+    }
+  },
+  "13311": {
+    "integrated_label": "Dining and Drinking > Restaurant > Molecular Gastronomy Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c2941735",
+      "foursquare_category_label": "Food > Molecular Gastronomy Restaurant",
+      "is_exact": true
+    }
+  },
+  "13312": {
+    "integrated_label": "Dining and Drinking > Restaurant > Mongolian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4eb1d5724b900d56c88a45fe",
+      "foursquare_category_label": "Food > Asian Restaurant > Mongolian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13313": {
+    "integrated_label": "Dining and Drinking > Restaurant > Moroccan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c3941735",
+      "foursquare_category_label": "Food > Mediterranean Restaurant > Moroccan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13314": {
+    "integrated_label": "Dining and Drinking > Restaurant > New American Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d157941735",
+      "foursquare_category_label": "Food > American Restaurant > New American Restaurant",
+      "is_exact": true
+    }
+  },
+  "13315": {
+    "integrated_label": "Dining and Drinking > Restaurant > Noodle Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d1941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Noodle House",
+      "is_exact": true
+    }
+  },
+  "13316": {
+    "integrated_label": "Dining and Drinking > Restaurant > Pakistani Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f8",
+      "foursquare_category_label": "Food > Pakistani Restaurant",
+      "is_exact": true
+    }
+  },
+  "13317": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b79f7",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13318": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Ash and Haleem Place",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1bc",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Ash and Haleem Place",
+      "is_exact": true
+    }
+  },
+  "13319": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Dizi Place",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1c0",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Dizi Place",
+      "is_exact": true
+    }
+  },
+  "13320": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Gilaki Restaurant",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1c4",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Gilaki Restaurant",
+      "is_exact": true
+    }
+  },
+  "13321": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Jegaraki",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1c7",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Jegaraki",
+      "is_exact": true
+    }
+  },
+  "13322": {
+    "integrated_label": "Dining and Drinking > Restaurant > Peruvian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4eb1bfa43b7b52c0e1adc2e8",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Peruvian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13323": {
+    "integrated_label": "Dining and Drinking > Restaurant > Peruvian Restaurant > Peruvian Roast Chicken Joint",
+    "single_match": {
+      "foursquare_category_id": "5f2c1c31b6d05514c704334c",
+      "foursquare_category_label": "Food > Peruvian Restaurants > Peruvian Roast Chicken Joint",
+      "is_exact": true
+    }
+  },
+  "13324": {
+    "integrated_label": "Dining and Drinking > Restaurant > Polish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a04",
+      "foursquare_category_label": "Food > Polish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13325": {
+    "integrated_label": "Dining and Drinking > Restaurant > Portuguese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4def73e84765ae376e57713a",
+      "foursquare_category_label": "Food > Portuguese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13326": {
+    "integrated_label": "Dining and Drinking > Restaurant > Poutine Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734c7",
+      "foursquare_category_label": "Food > Poutine Place",
+      "is_exact": true
+    }
+  },
+  "13327": {
+    "integrated_label": "Dining and Drinking > Restaurant > Puerto Rican Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c2abab6d05514c70446e4",
+      "foursquare_category_label": "Food > Caribbean Restaurants > Puerto Rican Restaurant",
+      "is_exact": true
+    }
+  },
+  "13328": {
+    "integrated_label": "Dining and Drinking > Restaurant > Romanian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52960bac3cf9994f4e043ac4",
+      "foursquare_category_label": "Food > Eastern European Restaurant > Romanian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13329": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5293a7563cf9994f4e043a44",
+      "foursquare_category_label": "Food > Russian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13330": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant > Blini House",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e9d",
+      "foursquare_category_label": "Food > Russian Restaurant > Blini House",
+      "is_exact": true
+    }
+  },
+  "13331": {
+    "integrated_label": "Dining and Drinking > Restaurant > Russian Restaurant > Pelmeni House",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e9c",
+      "foursquare_category_label": "Food > Russian Restaurant > Pelmeni House",
+      "is_exact": true
+    }
+  },
+  "13332": {
+    "integrated_label": "Dining and Drinking > Restaurant > Salad Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1bd941735",
+      "foursquare_category_label": "Food > Salad Place",
+      "is_exact": true
+    }
+  },
+  "13333": {
+    "integrated_label": "Dining and Drinking > Restaurant > Salvadoran Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5745c7ac498e5d0483112fdb",
+      "foursquare_category_label": "Food > Latin American Restaurant > Salvadoran Restaurant",
+      "is_exact": true
+    }
+  },
+  "13334": {
+    "integrated_label": "Dining and Drinking > Restaurant > Sandwich Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c5941735",
+      "foursquare_category_label": "Food > Sandwich Place",
+      "is_exact": true
+    }
+  },
+  "13335": {
+    "integrated_label": "Dining and Drinking > Restaurant > Satay Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57350e",
+      "foursquare_category_label": "Food > Asian Restaurant > Satay Restaurant",
+      "is_exact": true
+    }
+  },
+  "13336": {
+    "integrated_label": "Dining and Drinking > Restaurant > Scandinavian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c6941735",
+      "foursquare_category_label": "Food > Scandinavian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13337": {
+    "integrated_label": "Dining and Drinking > Restaurant > Scottish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5744ccdde4b0c0459246b4a3",
+      "foursquare_category_label": "Food > Scottish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13338": {
+    "integrated_label": "Dining and Drinking > Restaurant > Seafood Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ce941735",
+      "foursquare_category_label": "Food > Seafood Restaurant",
+      "is_exact": true
+    }
+  },
+  "13339": {
+    "integrated_label": "Dining and Drinking > Restaurant > Shawarma Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89e4",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Shawarma Place",
+      "is_exact": true
+    }
+  },
+  "13340": {
+    "integrated_label": "Dining and Drinking > Restaurant > Singaporean Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5f2c430e5b4c177b9a6dcabd",
+      "foursquare_category_label": "Food > Asian Restaurants > Singaporean Restaurant",
+      "is_exact": true
+    }
+  },
+  "13341": {
+    "integrated_label": "Dining and Drinking > Restaurant > Slovak Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57355a",
+      "foursquare_category_label": "Food > Slovak Restaurant",
+      "is_exact": true
+    }
+  },
+  "13342": {
+    "integrated_label": "Dining and Drinking > Restaurant > Soup Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1dd931735",
+      "foursquare_category_label": "Food > Soup Place",
+      "is_exact": true
+    }
+  },
+  "13343": {
+    "integrated_label": "Dining and Drinking > Restaurant > South American Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1cd941735",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant",
+      "is_exact": true
+    }
+  },
+  "13344": {
+    "integrated_label": "Dining and Drinking > Restaurant > Southern / Soul Food Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14f941735",
+      "foursquare_category_label": "Food > Southern / Soul Food Restaurant",
+      "is_exact": true
+    }
+  },
+  "13345": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d150941735",
+      "foursquare_category_label": "Food > Spanish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13346": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant > Paella Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14d941735",
+      "foursquare_category_label": "Food > Spanish Restaurant > Paella Restaurant",
+      "is_exact": true
+    }
+  },
+  "13347": {
+    "integrated_label": "Dining and Drinking > Restaurant > Spanish Restaurant > Tapas Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1db931735",
+      "foursquare_category_label": "Food > Spanish Restaurant > Tapas Restaurant",
+      "is_exact": true
+    }
+  },
+  "13348": {
+    "integrated_label": "Dining and Drinking > Restaurant > Sri Lankan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5413605de4b0ae91d18581a9",
+      "foursquare_category_label": "Food > Sri Lankan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13349": {
+    "integrated_label": "Dining and Drinking > Restaurant > Swiss Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d158941735",
+      "foursquare_category_label": "Food > Swiss Restaurant",
+      "is_exact": true
+    }
+  },
+  "13350": {
+    "integrated_label": "Dining and Drinking > Restaurant > Syrian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89da",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Syrian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13351": {
+    "integrated_label": "Dining and Drinking > Restaurant > Tatar Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e98",
+      "foursquare_category_label": "Food > Eastern European Restaurant > Tatar Restaurant",
+      "is_exact": true
+    }
+  },
+  "13352": {
+    "integrated_label": "Dining and Drinking > Restaurant > Thai Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d149941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Thai Restaurant",
+      "is_exact": true
+    }
+  },
+  "13353": {
+    "integrated_label": "Dining and Drinking > Restaurant > Thai Restaurant > Som Tum Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573502",
+      "foursquare_category_label": "Food > Asian Restaurant > Thai Restaurant > Som Tum Restaurant",
+      "is_exact": true
+    }
+  },
+  "13354": {
+    "integrated_label": "Dining and Drinking > Restaurant > Theme Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573538",
+      "foursquare_category_label": "Food > Theme Restaurant",
+      "is_exact": true
+    }
+  },
+  "13355": {
+    "integrated_label": "Dining and Drinking > Restaurant > Tibetan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52af39fb3cf9994f4e043be9",
+      "foursquare_category_label": "Food > Asian Restaurant > Tibetan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13356": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4f04af1f2fb6e1c99f3db0bb",
+      "foursquare_category_label": "Food > Turkish Restaurant",
+      "is_exact": true
+    }
+  },
+  "13357": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Borek Place",
+    "single_match": {
+      "foursquare_category_id": "530faca9bcbc57f1066bc2f3",
+      "foursquare_category_label": "Food > Turkish Restaurant > Borek Place",
+      "is_exact": true
+    }
+  },
+  "13358": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Cigkofte Place",
+    "single_match": {
+      "foursquare_category_id": "530faca9bcbc57f1066bc2f4",
+      "foursquare_category_label": "Food > Turkish Restaurant > Cigkofte Place",
+      "is_exact": true
+    }
+  },
+  "13359": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Çöp Şiş Place",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1e2",
+      "foursquare_category_label": "Food > Turkish Restaurant > Çöp Şiş Place",
+      "is_exact": true
+    }
+  },
+  "13360": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Doner Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d8",
+      "foursquare_category_label": "Food > Turkish Restaurant > Doner Restaurant",
+      "is_exact": true
+    }
+  },
+  "13361": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Gozleme Place",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d9",
+      "foursquare_category_label": "Food > Turkish Restaurant > Gozleme Place",
+      "is_exact": true
+    }
+  },
+  "13362": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kofte Place",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88db",
+      "foursquare_category_label": "Food > Turkish Restaurant > Kofte Place",
+      "is_exact": true
+    }
+  },
+  "13363": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kokoreç Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d6",
+      "foursquare_category_label": "Food > Turkish Restaurant > Kokoreç Restaurant",
+      "is_exact": true
+    }
+  },
+  "13364": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kumpir Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573535",
+      "foursquare_category_label": "Food > Turkish Restaurant > Kumpir Restaurant",
+      "is_exact": true
+    }
+  },
+  "13365": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Kumru Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734bd",
+      "foursquare_category_label": "Food > Turkish Restaurant > Kumru Restaurant",
+      "is_exact": true
+    }
+  },
+  "13366": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Manti Place",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d5",
+      "foursquare_category_label": "Food > Turkish Restaurant > Manti Place",
+      "is_exact": true
+    }
+  },
+  "13367": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Meyhane",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88da",
+      "foursquare_category_label": "Food > Turkish Restaurant > Meyhane",
+      "is_exact": true
+    }
+  },
+  "13368": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Pide Place",
+    "single_match": {
+      "foursquare_category_id": "530faca9bcbc57f1066bc2f2",
+      "foursquare_category_label": "Food > Turkish Restaurant > Pide Place",
+      "is_exact": true
+    }
+  },
+  "13369": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Pilavcı",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1df",
+      "foursquare_category_label": "Food > Turkish Restaurant > Pilavcı",
+      "is_exact": true
+    }
+  },
+  "13370": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Söğüş Place",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1dc",
+      "foursquare_category_label": "Food > Turkish Restaurant > Söğüş Place",
+      "is_exact": true
+    }
+  },
+  "13371": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Tantuni Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734bf",
+      "foursquare_category_label": "Food > Turkish Restaurant > Tantuni Restaurant",
+      "is_exact": true
+    }
+  },
+  "13372": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Turkish Coffeehouse",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734c1",
+      "foursquare_category_label": "Food > Turkish Restaurant > Turkish Coffeehouse",
+      "is_exact": true
+    }
+  },
+  "13373": {
+    "integrated_label": "Dining and Drinking > Restaurant > Turkish Restaurant > Turkish Home Cooking Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5283c7b4e4b094cb91ec88d4",
+      "foursquare_category_label": "Food > Turkish Restaurant > Turkish Home Cooking Restaurant",
+      "is_exact": true
+    }
+  },
+  "13374": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e96",
+      "foursquare_category_label": "Food > Ukrainian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13375": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant > Varenyky Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e9a",
+      "foursquare_category_label": "Food > Ukrainian Restaurant > Varenyky restaurant",
+      "is_exact": true
+    }
+  },
+  "13376": {
+    "integrated_label": "Dining and Drinking > Restaurant > Ukrainian Restaurant > West-Ukrainian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "52e928d0bcbc57f1066b7e9b",
+      "foursquare_category_label": "Food > Ukrainian Restaurant > West-Ukrainian Restaurant",
+      "is_exact": true
+    }
+  },
+  "13377": {
+    "integrated_label": "Dining and Drinking > Restaurant > Vegan and Vegetarian Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1d3941735",
+      "foursquare_category_label": "Food > Vegetarian / Vegan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13378": {
+    "integrated_label": "Dining and Drinking > Restaurant > Venezuelan Restaurant",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573558",
+      "foursquare_category_label": "Food > Latin American Restaurant > South American Restaurant > Venezuelan Restaurant",
+      "is_exact": true
+    }
+  },
+  "13379": {
+    "integrated_label": "Dining and Drinking > Restaurant > Vietnamese Restaurant",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14a941735",
+      "foursquare_category_label": "Food > Asian Restaurant > Vietnamese Restaurant",
+      "is_exact": true
+    }
+  },
+  "13380": {
+    "integrated_label": "Dining and Drinking > Restaurant > Yemeni Restaurant",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89ea",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Yemeni Restaurant",
+      "is_exact": true
+    }
+  },
+  "13381": {
+    "integrated_label": "Dining and Drinking > Smoothie Shop",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b41",
+      "foursquare_category_label": "Shop & Service > Smoothie Shop",
+      "is_exact": true
+    }
+  },
+  "13382": {
+    "integrated_label": "Dining and Drinking > Snack Place",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1c7941735",
+      "foursquare_category_label": "Food > Snack Place",
+      "is_exact": true
+    }
+  },
+  "13383": {
+    "integrated_label": "Dining and Drinking > Restaurant > Steakhouse",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1cc941735",
+      "foursquare_category_label": "Food > Steakhouse",
+      "is_exact": true
+    }
+  },
+  "13384": {
+    "integrated_label": "Dining and Drinking > Restaurant > Persian Restaurant > Tabbakhi",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4a8",
+      "foursquare_category_label": "Food > Middle Eastern Restaurant > Persian Restaurant > Tabbakhi",
+      "is_exact": true
+    }
+  },
+  "13385": {
+    "integrated_label": "Dining and Drinking > Truck Stop",
+    "single_match": {
+      "foursquare_category_id": "57558b36e4b065ecebd306dd",
+      "foursquare_category_label": "Food > Truck Stop",
+      "is_exact": true
+    }
+  },
+  "13386": {
+    "integrated_label": "Dining and Drinking > Vineyard",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1de941735",
+      "foursquare_category_label": "Outdoors & Recreation > Vineyard",
+      "is_exact": true
+    }
+  },
+  "13387": {
+    "integrated_label": "Dining and Drinking > Winery",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14b941735",
+      "foursquare_category_label": "Professional & Other Places > Winery",
+      "is_exact": true
+    }
+  },
+  "13388": {
+    "integrated_label": "Dining and Drinking > Restaurant > Wings Joint",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d14c941735",
+      "foursquare_category_label": "Food > Wings Joint",
+      "is_exact": true
+    }
+  },
+  "14000": {
+    "integrated_label": "Event",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06373d81259",
+      "foursquare_category_label": "Event",
+      "is_exact": true
+    }
+  },
+  "14001": {
+    "integrated_label": "Event > Conference",
+    "single_match": {
+      "foursquare_category_id": "5267e4d9e4b0ec79466e48c6",
+      "foursquare_category_label": "Event > Conference",
+      "is_exact": true
+    }
+  },
+  "14002": {
+    "integrated_label": "Event > Convention",
+    "single_match": {
+      "foursquare_category_id": "5267e4d9e4b0ec79466e48c9",
+      "foursquare_category_label": "Event > Convention",
+      "is_exact": true
+    }
+  },
+  "14003": {
+    "integrated_label": "Event > Entertainment Event",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06373d81259",
+      "foursquare_category_label": "Event",
+      "is_exact": false
+    }
+  },
+  "14004": {
+    "integrated_label": "Event > Entertainment Event > Festival",
+    "single_match": {
+      "foursquare_category_id": "5267e4d9e4b0ec79466e48c7",
+      "foursquare_category_label": "Event > Festival",
+      "is_exact": true
+    }
+  },
+  "14005": {
+    "integrated_label": "Event > Entertainment Event > Music Festival",
+    "single_match": {
+      "foursquare_category_id": "5267e4d9e4b0ec79466e48d1",
+      "foursquare_category_label": "Event > Music Festival",
+      "is_exact": true
+    }
+  },
+  "14006": {
+    "integrated_label": "Event > Entertainment Event > Parade",
+    "single_match": {
+      "foursquare_category_id": "52741d85e4b0d5d1e3c6a6d9",
+      "foursquare_category_label": "Event > Parade",
+      "is_exact": true
+    }
+  },
+  "14007": {
+    "integrated_label": "Event > Entertainment Event > Sporting Event",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89c5",
+      "foursquare_category_label": "Event > Sporting Event",
+      "is_exact": true
+    }
+  },
+  "14008": {
+    "integrated_label": "Event > Line / Queue",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1fa",
+      "foursquare_category_label": "Event > Line / Queue",
+      "is_exact": true
+    }
+  },
+  "14009": {
+    "integrated_label": "Event > Marketplace",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06373d81259",
+      "foursquare_category_label": "Event",
+      "is_exact": false
+    }
+  },
+  "14010": {
+    "integrated_label": "Event > Marketplace > Christmas Market",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3b",
+      "foursquare_category_label": "Event > Christmas Market",
+      "is_exact": true
+    }
+  },
+  "14011": {
+    "integrated_label": "Event > Marketplace > Stoop Sale",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b54",
+      "foursquare_category_label": "Event > Stoop Sale",
+      "is_exact": true
+    }
+  },
+  "14012": {
+    "integrated_label": "Event > Marketplace > Street Fair",
+    "single_match": {
+      "foursquare_category_id": "5267e4d8e4b0ec79466e48c5",
+      "foursquare_category_label": "Event > Street Fair",
+      "is_exact": true
+    }
+  },
+  "14013": {
+    "integrated_label": "Event > Marketplace > Street Food Gathering",
+    "single_match": {
+      "foursquare_category_id": "53e0feef498e5aac066fd8a9",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Street Food Gathering",
+      "is_exact": true
+    }
+  },
+  "14014": {
+    "integrated_label": "Event > Marketplace > Trade Fair",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89c3",
+      "foursquare_category_label": "Event > Trade Fair",
+      "is_exact": true
+    }
+  },
+  "14015": {
+    "integrated_label": "Event > Other Event",
+    "single_match": {
+      "foursquare_category_id": "5267e4d9e4b0ec79466e48c8",
+      "foursquare_category_label": "Event > Other Event",
+      "is_exact": true
+    }
+  },
+  "15000": {
+    "integrated_label": "Health and Medicine",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15001": {
+    "integrated_label": "Health and Medicine > Acupuncture Clinic",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3b",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Acupuncturist",
+      "is_exact": true
+    }
+  },
+  "15002": {
+    "integrated_label": "Health and Medicine > AIDS Resource",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15003": {
+    "integrated_label": "Health and Medicine > Alternative Medicine Clinic",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3c",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Alternative Healer",
+      "is_exact": true
+    }
+  },
+  "15004": {
+    "integrated_label": "Health and Medicine > Assisted Living Service",
+    "single_match": {
+      "foursquare_category_id": "5032891291d4c4b30a586d68",
+      "foursquare_category_label": "Residence > Assisted Living",
+      "is_exact": true
+    }
+  },
+  "15005": {
+    "integrated_label": "Health and Medicine > Blood Bank",
+    "single_match": {
+      "foursquare_category_id": "5f2c43a65b4c177b9a6dcc62",
+      "foursquare_category_label": "Professional & Other Places > Medical Centers > Blood Donation Center",
+      "is_exact": true
+    }
+  },
+  "15006": {
+    "integrated_label": "Health and Medicine > Chiropractor",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a3a",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Chiropractor",
+      "is_exact": true
+    }
+  },
+  "15007": {
+    "integrated_label": "Health and Medicine > Dentist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d178941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Dentist's Office",
+      "is_exact": true
+    }
+  },
+  "15008": {
+    "integrated_label": "Health and Medicine > Emergency Service",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15009": {
+    "integrated_label": "Health and Medicine > Emergency Service > Ambulance Service",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15010": {
+    "integrated_label": "Health and Medicine > Emergency Service > Emergency Room",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d194941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Emergency Room",
+      "is_exact": true
+    }
+  },
+  "15011": {
+    "integrated_label": "Health and Medicine > Healthcare Clinic",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15012": {
+    "integrated_label": "Health and Medicine > Home Health Care Service",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06375d81259",
+      "foursquare_category_label": "Professional & Other Places",
+      "is_exact": false
+    }
+  },
+  "15013": {
+    "integrated_label": "Health and Medicine > Hospice",
+    "single_match": {
+      "foursquare_category_id": "5f2c5b8b5b4c177b9a6ddf0b",
+      "foursquare_category_label": "Professional & Other Places > Medical Centers > Hospice",
+      "is_exact": true
+    }
+  },
+  "15014": {
+    "integrated_label": "Health and Medicine > Hospital",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d196941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Hospital",
+      "is_exact": true
+    }
+  },
+  "15015": {
+    "integrated_label": "Health and Medicine > Maternity Clinic",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734ff",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Maternity Clinic",
+      "is_exact": true
+    }
+  },
+  "15016": {
+    "integrated_label": "Health and Medicine > Medical Center",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": true
+    }
+  },
+  "15017": {
+    "integrated_label": "Health and Medicine > Medical Lab",
+    "single_match": {
+      "foursquare_category_id": "4f4531b14b9074f6e4fb0103",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Medical Lab",
+      "is_exact": true
+    }
+  },
+  "15018": {
+    "integrated_label": "Health and Medicine > Mental Health Service",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15019": {
+    "integrated_label": "Health and Medicine > Mental Health Service > Mental Health Clinic",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a39",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Mental Health Office",
+      "is_exact": true
+    }
+  },
+  "15020": {
+    "integrated_label": "Health and Medicine > Mental Health Service > Psychologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15021": {
+    "integrated_label": "Health and Medicine > Nurse",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15022": {
+    "integrated_label": "Health and Medicine > Nursing Home",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15023": {
+    "integrated_label": "Health and Medicine > Nutritionist",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1d0",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Nutritionist",
+      "is_exact": true
+    }
+  },
+  "15024": {
+    "integrated_label": "Health and Medicine > Optometrist",
+    "single_match": {
+      "foursquare_category_id": "522e32fae4b09b556e370f19",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Eye Doctor",
+      "is_exact": false
+    }
+  },
+  "15025": {
+    "integrated_label": "Health and Medicine > Other Healthcare Professional",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15026": {
+    "integrated_label": "Health and Medicine > Physical Therapy Clinic",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4af",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Physical Therapist",
+      "is_exact": true
+    }
+  },
+  "15027": {
+    "integrated_label": "Health and Medicine > Physician",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15028": {
+    "integrated_label": "Health and Medicine > Physician > Anesthesiologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15029": {
+    "integrated_label": "Health and Medicine > Physician > Cardiologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15030": {
+    "integrated_label": "Health and Medicine > Physician > Dermatologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15031": {
+    "integrated_label": "Health and Medicine > Physician > Doctor's Office",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15032": {
+    "integrated_label": "Health and Medicine > Physician > Ear, Nose and Throat Doctor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15033": {
+    "integrated_label": "Health and Medicine > Physician > Family Medicine Doctor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15034": {
+    "integrated_label": "Health and Medicine > Physician > Gastroenterologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15035": {
+    "integrated_label": "Health and Medicine > Physician > General Surgeon",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15036": {
+    "integrated_label": "Health and Medicine > Physician > Geriatric Doctor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15037": {
+    "integrated_label": "Health and Medicine > Physician > Internal Medicine Doctor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15038": {
+    "integrated_label": "Health and Medicine > Physician > Neurologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15039": {
+    "integrated_label": "Health and Medicine > Physician > Obstetrician Gynecologist (Ob-gyn)",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15040": {
+    "integrated_label": "Health and Medicine > Physician > Oncologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15041": {
+    "integrated_label": "Health and Medicine > Physician > Ophthalmologist",
+    "single_match": {
+      "foursquare_category_id": "522e32fae4b09b556e370f19",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Eye Doctor",
+      "is_exact": false
+    }
+  },
+  "15042": {
+    "integrated_label": "Health and Medicine > Physician > Oral Surgeon",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15043": {
+    "integrated_label": "Health and Medicine > Physician > Orthopedic Surgeon",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15044": {
+    "integrated_label": "Health and Medicine > Physician > Pathologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15045": {
+    "integrated_label": "Health and Medicine > Physician > Pediatrician",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15046": {
+    "integrated_label": "Health and Medicine > Physician > Plastic Surgeon",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15047": {
+    "integrated_label": "Health and Medicine > Physician > Psychiatrist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15048": {
+    "integrated_label": "Health and Medicine > Physician > Radiologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15049": {
+    "integrated_label": "Health and Medicine > Physician > Respiratory Doctor",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15050": {
+    "integrated_label": "Health and Medicine > Physician > Urologist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15051": {
+    "integrated_label": "Health and Medicine > Podiatrist",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d177941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Doctor's Office",
+      "is_exact": false
+    }
+  },
+  "15052": {
+    "integrated_label": "Health and Medicine > Sports Medicine Clinic",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "15053": {
+    "integrated_label": "Health and Medicine > Urgent Care Center",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573526",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Urgent Care Center",
+      "is_exact": true
+    }
+  },
+  "15054": {
+    "integrated_label": "Health and Medicine > Veterinarian",
+    "single_match": {
+      "foursquare_category_id": "4d954af4a243a5684765b473",
+      "foursquare_category_label": "Professional & Other Places > Medical Center > Veterinarian",
+      "is_exact": true
+    }
+  },
+  "15055": {
+    "integrated_label": "Health and Medicine > Weight Loss Center",
+    "single_match": {
+      "foursquare_category_id": "590a0744340a5803fd8508c3",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Weight Loss Center",
+      "is_exact": true
+    }
+  },
+  "15056": {
+    "integrated_label": "Health and Medicine > Women's Health Clinic",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104941735",
+      "foursquare_category_label": "Professional & Other Places > Medical Center",
+      "is_exact": false
+    }
+  },
+  "16000": {
+    "integrated_label": "Landmarks and Outdoors",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06377d81259",
+      "foursquare_category_label": "Outdoors & Recreation",
+      "is_exact": false
+    }
+  },
+  "16001": {
+    "integrated_label": "Landmarks and Outdoors > Bathing Area",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a28",
+      "foursquare_category_label": "Outdoors & Recreation > Bathing Area",
+      "is_exact": true
+    }
+  },
+  "16002": {
+    "integrated_label": "Landmarks and Outdoors > Bay",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573544",
+      "foursquare_category_label": "Outdoors & Recreation > Bay",
+      "is_exact": true
+    }
+  },
+  "16003": {
+    "integrated_label": "Landmarks and Outdoors > Beach",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e2941735",
+      "foursquare_category_label": "Outdoors & Recreation > Beach",
+      "is_exact": true
+    }
+  },
+  "16004": {
+    "integrated_label": "Landmarks and Outdoors > Bike Trail",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57355e",
+      "foursquare_category_label": "Outdoors & Recreation > Bike Trail",
+      "is_exact": true
+    }
+  },
+  "16005": {
+    "integrated_label": "Landmarks and Outdoors > Botanical Garden",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a22",
+      "foursquare_category_label": "Outdoors & Recreation > Botanical Garden",
+      "is_exact": true
+    }
+  },
+  "16006": {
+    "integrated_label": "Landmarks and Outdoors > Bridge",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1df941735",
+      "foursquare_category_label": "Outdoors & Recreation > Bridge",
+      "is_exact": true
+    }
+  },
+  "16007": {
+    "integrated_label": "Landmarks and Outdoors > Building / Structure",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d130941735",
+      "foursquare_category_label": "Professional & Other Places > Building",
+      "is_exact": true
+    }
+  },
+  "16008": {
+    "integrated_label": "Landmarks and Outdoors > Campground",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e4941735",
+      "foursquare_category_label": "Outdoors & Recreation > Campground",
+      "is_exact": true
+    }
+  },
+  "16009": {
+    "integrated_label": "Landmarks and Outdoors > Canal",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573562",
+      "foursquare_category_label": "Outdoors & Recreation > Canal",
+      "is_exact": true
+    }
+  },
+  "16010": {
+    "integrated_label": "Landmarks and Outdoors > Canal Lock",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57353b",
+      "foursquare_category_label": "Outdoors & Recreation > Canal Lock",
+      "is_exact": true
+    }
+  },
+  "16011": {
+    "integrated_label": "Landmarks and Outdoors > Castle",
+    "single_match": {
+      "foursquare_category_id": "50aaa49e4b90af0d42d5de11",
+      "foursquare_category_label": "Outdoors & Recreation > Castle",
+      "is_exact": true
+    }
+  },
+  "16012": {
+    "integrated_label": "Landmarks and Outdoors > Cave",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573511",
+      "foursquare_category_label": "Outdoors & Recreation > Cave",
+      "is_exact": true
+    }
+  },
+  "16013": {
+    "integrated_label": "Landmarks and Outdoors > Dive Spot",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a12",
+      "foursquare_category_label": "Outdoors & Recreation > Dive Spot",
+      "is_exact": true
+    }
+  },
+  "16014": {
+    "integrated_label": "Landmarks and Outdoors > Farm",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d15b941735",
+      "foursquare_category_label": "Outdoors & Recreation > Farm",
+      "is_exact": true
+    }
+  },
+  "16015": {
+    "integrated_label": "Landmarks and Outdoors > Forest",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a23",
+      "foursquare_category_label": "Outdoors & Recreation > Forest",
+      "is_exact": true
+    }
+  },
+  "16016": {
+    "integrated_label": "Landmarks and Outdoors > Fountain",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573547",
+      "foursquare_category_label": "Outdoors & Recreation > Fountain",
+      "is_exact": true
+    }
+  },
+  "16017": {
+    "integrated_label": "Landmarks and Outdoors > Garden",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d15a941735",
+      "foursquare_category_label": "Outdoors & Recreation > Garden",
+      "is_exact": true
+    }
+  },
+  "16018": {
+    "integrated_label": "Landmarks and Outdoors > Harbor / Marina",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e0941735",
+      "foursquare_category_label": "Outdoors & Recreation > Harbor / Marina",
+      "is_exact": true
+    }
+  },
+  "16019": {
+    "integrated_label": "Landmarks and Outdoors > Hiking Trail",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d159941735",
+      "foursquare_category_label": "Outdoors & Recreation > Trail",
+      "is_exact": true
+    }
+  },
+  "16020": {
+    "integrated_label": "Landmarks and Outdoors > Historic and Protected Site",
+    "single_match": {
+      "foursquare_category_id": "4deefb944765f83613cdba6e",
+      "foursquare_category_label": "Arts & Entertainment > Historic Site",
+      "is_exact": true
+    }
+  },
+  "16021": {
+    "integrated_label": "Landmarks and Outdoors > Hot Spring",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d160941735",
+      "foursquare_category_label": "Outdoors & Recreation > Hot Spring",
+      "is_exact": true
+    }
+  },
+  "16022": {
+    "integrated_label": "Landmarks and Outdoors > Island",
+    "single_match": {
+      "foursquare_category_id": "50aaa4314b90af0d42d5de10",
+      "foursquare_category_label": "Outdoors & Recreation > Island",
+      "is_exact": true
+    }
+  },
+  "16023": {
+    "integrated_label": "Landmarks and Outdoors > Lake",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d161941735",
+      "foursquare_category_label": "Outdoors & Recreation > Lake",
+      "is_exact": true
+    }
+  },
+  "16024": {
+    "integrated_label": "Landmarks and Outdoors > Lighthouse",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d15d941735",
+      "foursquare_category_label": "Outdoors & Recreation > Lighthouse",
+      "is_exact": true
+    }
+  },
+  "16025": {
+    "integrated_label": "Landmarks and Outdoors > Memorial Site",
+    "single_match": {
+      "foursquare_category_id": "5642206c498e4bfca532186c",
+      "foursquare_category_label": "Arts & Entertainment > Memorial Site",
+      "is_exact": true
+    }
+  },
+  "16026": {
+    "integrated_label": "Landmarks and Outdoors > Monument",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12d941735",
+      "foursquare_category_label": "Professional & Other Places > Government Building > Monument / Landmark",
+      "is_exact": true
+    }
+  },
+  "16027": {
+    "integrated_label": "Landmarks and Outdoors > Mountain",
+    "single_match": {
+      "foursquare_category_id": "4eb1d4d54b900d56c88a45fc",
+      "foursquare_category_label": "Outdoors & Recreation > Mountain",
+      "is_exact": true
+    }
+  },
+  "16028": {
+    "integrated_label": "Landmarks and Outdoors > Nature Preserve",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a13",
+      "foursquare_category_label": "Outdoors & Recreation > Nature Preserve",
+      "is_exact": true
+    }
+  },
+  "16029": {
+    "integrated_label": "Landmarks and Outdoors > Nudist Beach",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a30",
+      "foursquare_category_label": "Outdoors & Recreation > Beach > Nudist Beach",
+      "is_exact": true
+    }
+  },
+  "16030": {
+    "integrated_label": "Landmarks and Outdoors > Other Great Outdoors",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d162941735",
+      "foursquare_category_label": "Outdoors & Recreation > Other Great Outdoors",
+      "is_exact": true
+    }
+  },
+  "16031": {
+    "integrated_label": "Landmarks and Outdoors > Palace",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a14",
+      "foursquare_category_label": "Outdoors & Recreation > Palace",
+      "is_exact": true
+    }
+  },
+  "16032": {
+    "integrated_label": "Landmarks and Outdoors > Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d163941735",
+      "foursquare_category_label": "Outdoors & Recreation > Park",
+      "is_exact": true
+    }
+  },
+  "16033": {
+    "integrated_label": "Landmarks and Outdoors > Park > Dog Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e5941735",
+      "foursquare_category_label": "Outdoors & Recreation > Dog Run",
+      "is_exact": true
+    }
+  },
+  "16034": {
+    "integrated_label": "Landmarks and Outdoors > Park > National Park",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a21",
+      "foursquare_category_label": "Outdoors & Recreation > National Park",
+      "is_exact": true
+    }
+  },
+  "16035": {
+    "integrated_label": "Landmarks and Outdoors > Park > Natural Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d163941735",
+      "foursquare_category_label": "Outdoors & Recreation > Park",
+      "is_exact": false
+    }
+  },
+  "16036": {
+    "integrated_label": "Landmarks and Outdoors > Park > Picnic Area",
+    "single_match": {
+      "foursquare_category_id": "5fabfe3599ce226e27fe709a",
+      "foursquare_category_label": "Outdoors & Recreation > Picnic Area",
+      "is_exact": true
+    }
+  },
+  "16037": {
+    "integrated_label": "Landmarks and Outdoors > Park > Playground",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e7941735",
+      "foursquare_category_label": "Outdoors & Recreation > Playground",
+      "is_exact": true
+    }
+  },
+  "16038": {
+    "integrated_label": "Landmarks and Outdoors > Park > State / Provincial Park",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89d0",
+      "foursquare_category_label": "Outdoors & Recreation > State / Provincial Park",
+      "is_exact": true
+    }
+  },
+  "16039": {
+    "integrated_label": "Landmarks and Outdoors > Park > Urban Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d163941735",
+      "foursquare_category_label": "Outdoors & Recreation > Park",
+      "is_exact": false
+    }
+  },
+  "16040": {
+    "integrated_label": "Landmarks and Outdoors > Pedestrian Plaza",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a25",
+      "foursquare_category_label": "Outdoors & Recreation > Pedestrian Plaza",
+      "is_exact": true
+    }
+  },
+  "16041": {
+    "integrated_label": "Landmarks and Outdoors > Plaza",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d164941735",
+      "foursquare_category_label": "Outdoors & Recreation > Plaza",
+      "is_exact": true
+    }
+  },
+  "16042": {
+    "integrated_label": "Landmarks and Outdoors > Reservoir",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573541",
+      "foursquare_category_label": "Outdoors & Recreation > Reservoir",
+      "is_exact": true
+    }
+  },
+  "16043": {
+    "integrated_label": "Landmarks and Outdoors > River",
+    "single_match": {
+      "foursquare_category_id": "4eb1d4dd4b900d56c88a45fd",
+      "foursquare_category_label": "Outdoors & Recreation > River",
+      "is_exact": true
+    }
+  },
+  "16044": {
+    "integrated_label": "Landmarks and Outdoors > Rock Climbing Spot",
+    "single_match": {
+      "foursquare_category_id": "50328a4b91d4c4b30a586d6b",
+      "foursquare_category_label": "Outdoors & Recreation > Rock Climbing Spot",
+      "is_exact": true
+    }
+  },
+  "16045": {
+    "integrated_label": "Landmarks and Outdoors > Roof Deck",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d133951735",
+      "foursquare_category_label": "Outdoors & Recreation > Roof Deck",
+      "is_exact": true
+    }
+  },
+  "16046": {
+    "integrated_label": "Landmarks and Outdoors > Scenic Lookout",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d165941735",
+      "foursquare_category_label": "Outdoors & Recreation > Scenic Lookout",
+      "is_exact": true
+    }
+  },
+  "16047": {
+    "integrated_label": "Landmarks and Outdoors > Sculpture Garden",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d166941735",
+      "foursquare_category_label": "Outdoors & Recreation > Sculpture Garden",
+      "is_exact": true
+    }
+  },
+  "16048": {
+    "integrated_label": "Landmarks and Outdoors > Stable",
+    "single_match": {
+      "foursquare_category_id": "4eb1baf03b7b2c5b1d4306ca",
+      "foursquare_category_label": "Outdoors & Recreation > Stable",
+      "is_exact": true
+    }
+  },
+  "16049": {
+    "integrated_label": "Landmarks and Outdoors > Surf Spot",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e3941735",
+      "foursquare_category_label": "Outdoors & Recreation > Beach > Surf Spot",
+      "is_exact": true
+    }
+  },
+  "16050": {
+    "integrated_label": "Landmarks and Outdoors > Tunnel",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b4a",
+      "foursquare_category_label": "Travel & Transport > Tunnel",
+      "is_exact": true
+    }
+  },
+  "16051": {
+    "integrated_label": "Landmarks and Outdoors > Volcano",
+    "single_match": {
+      "foursquare_category_id": "5032848691d4c4b30a586d61",
+      "foursquare_category_label": "Outdoors & Recreation > Volcano",
+      "is_exact": true
+    }
+  },
+  "16052": {
+    "integrated_label": "Landmarks and Outdoors > Waterfall",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573560",
+      "foursquare_category_label": "Outdoors & Recreation > Waterfall",
+      "is_exact": true
+    }
+  },
+  "16053": {
+    "integrated_label": "Landmarks and Outdoors > Waterfront",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734c3",
+      "foursquare_category_label": "Outdoors & Recreation > Waterfront",
+      "is_exact": true
+    }
+  },
+  "16054": {
+    "integrated_label": "Landmarks and Outdoors > Windmill",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89c7",
+      "foursquare_category_label": "Outdoors & Recreation > Windmill",
+      "is_exact": true
+    }
+  },
+  "17000": {
+    "integrated_label": "Retail",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17001": {
+    "integrated_label": "Retail > Adult Store",
+    "single_match": {
+      "foursquare_category_id": "5267e446e4b0ec79466e48c4",
+      "foursquare_category_label": "Shop & Service > Adult Boutique",
+      "is_exact": true
+    }
+  },
+  "17002": {
+    "integrated_label": "Retail > Antique Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d116951735",
+      "foursquare_category_label": "Shop & Service > Antique Shop",
+      "is_exact": true
+    }
+  },
+  "17003": {
+    "integrated_label": "Retail > Arts and Crafts Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d127951735",
+      "foursquare_category_label": "Shop & Service > Arts & Crafts Store",
+      "is_exact": true
+    }
+  },
+  "17004": {
+    "integrated_label": "Retail > Auction House",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17005": {
+    "integrated_label": "Retail > Automotive Retail",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d124951735",
+      "foursquare_category_label": "Shop & Service > Automotive Shop",
+      "is_exact": true
+    }
+  },
+  "17006": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership",
+    "single_match": {
+      "foursquare_category_id": "4eb1c1623b7b52c0e1adc2ec",
+      "foursquare_category_label": "Shop & Service > Auto Dealership",
+      "is_exact": true
+    }
+  },
+  "17007": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > Classic and Antique Car Dealership",
+    "single_match": {
+      "foursquare_category_id": "4eb1c1623b7b52c0e1adc2ec",
+      "foursquare_category_label": "Shop & Service > Auto Dealership",
+      "is_exact": false
+    }
+  },
+  "17008": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > New Car Dealership",
+    "single_match": {
+      "foursquare_category_id": "5e8f50bd03c7a9000c1e2fbc",
+      "foursquare_category_label": "Shop & Service > Auto Dealership > New Auto Dealership",
+      "is_exact": true
+    }
+  },
+  "17009": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > RV and Motorhome Dealership",
+    "single_match": {
+      "foursquare_category_id": "4eb1c1623b7b52c0e1adc2ec",
+      "foursquare_category_label": "Shop & Service > Auto Dealership",
+      "is_exact": false
+    }
+  },
+  "17010": {
+    "integrated_label": "Retail > Automotive Retail > Car Dealership > Used Car Dealership",
+    "single_match": {
+      "foursquare_category_id": "5e8f501a03c7a9000c1e2e88",
+      "foursquare_category_label": "Shop & Service > Auto Dealership > Used Auto Dealership",
+      "is_exact": true
+    }
+  },
+  "17011": {
+    "integrated_label": "Retail > Automotive Retail > Car Parts and Accessories",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17012": {
+    "integrated_label": "Retail > Automotive Retail > Motorcycle Dealership",
+    "single_match": {
+      "foursquare_category_id": "5032833091d4c4b30a586d60",
+      "foursquare_category_label": "Shop & Service > Motorcycle Shop",
+      "is_exact": true
+    }
+  },
+  "17013": {
+    "integrated_label": "Retail > Automotive Retail > Motorsports Store",
+    "single_match": {
+      "foursquare_category_id": "59d79d6b2e268052fa2a3332",
+      "foursquare_category_label": "Shop & Service > Motorsports Shop",
+      "is_exact": true
+    }
+  },
+  "17014": {
+    "integrated_label": "Retail > Baby Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b32",
+      "foursquare_category_label": "Shop & Service > Baby Store",
+      "is_exact": true
+    }
+  },
+  "17015": {
+    "integrated_label": "Retail > Betting Shop",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b40",
+      "foursquare_category_label": "Shop & Service > Betting Shop",
+      "is_exact": true
+    }
+  },
+  "17016": {
+    "integrated_label": "Retail > Big Box Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b42",
+      "foursquare_category_label": "Shop & Service > Big Box Store",
+      "is_exact": true
+    }
+  },
+  "17017": {
+    "integrated_label": "Retail > Board Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f1941735",
+      "foursquare_category_label": "Shop & Service > Board Shop",
+      "is_exact": true
+    }
+  },
+  "17018": {
+    "integrated_label": "Retail > Bookstore",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d114951735",
+      "foursquare_category_label": "Shop & Service > Bookstore",
+      "is_exact": true
+    }
+  },
+  "17019": {
+    "integrated_label": "Retail > Bookstore > Used Bookstore",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b30",
+      "foursquare_category_label": "Shop & Service > Used Bookstore",
+      "is_exact": true
+    }
+  },
+  "17020": {
+    "integrated_label": "Retail > Boutique",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d104951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Boutique",
+      "is_exact": true
+    }
+  },
+  "17021": {
+    "integrated_label": "Retail > Cannabis Store",
+    "single_match": {
+      "foursquare_category_id": "52c71aaf3cf9994f4e043d17",
+      "foursquare_category_label": "Shop & Service > Marijuana Dispensary",
+      "is_exact": true
+    }
+  },
+  "17022": {
+    "integrated_label": "Retail > Comic Book Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b18",
+      "foursquare_category_label": "Shop & Service > Comic Shop",
+      "is_exact": true
+    }
+  },
+  "17023": {
+    "integrated_label": "Retail > Computers and Electronics Retail",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17024": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Camera Store",
+    "single_match": {
+      "foursquare_category_id": "4eb1bdf03b7b55596b4a7491",
+      "foursquare_category_label": "Shop & Service > Camera Store",
+      "is_exact": true
+    }
+  },
+  "17025": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Electronics Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d122951735",
+      "foursquare_category_label": "Shop & Service > Electronics Store",
+      "is_exact": true
+    }
+  },
+  "17026": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Mobile Phone Store",
+    "single_match": {
+      "foursquare_category_id": "4f04afc02fb6e1c99f3db0bc",
+      "foursquare_category_label": "Shop & Service > Mobile Phone Shop",
+      "is_exact": true
+    }
+  },
+  "17027": {
+    "integrated_label": "Retail > Computers and Electronics Retail > Video Games Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10b951735",
+      "foursquare_category_label": "Shop & Service > Video Game Store",
+      "is_exact": true
+    }
+  },
+  "17028": {
+    "integrated_label": "Retail > Construction Supplies Store",
+    "single_match": {
+      "foursquare_category_id": "5454144b498ec1f095bff2f2",
+      "foursquare_category_label": "Shop & Service > Construction & Landscaping",
+      "is_exact": false
+    }
+  },
+  "17029": {
+    "integrated_label": "Retail > Convenience Store",
+    "single_match": {
+      "foursquare_category_id": "4d954b0ea243a5684a65b473",
+      "foursquare_category_label": "Shop & Service > Convenience Store",
+      "is_exact": true
+    }
+  },
+  "17030": {
+    "integrated_label": "Retail > Cosmetics Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10c951735",
+      "foursquare_category_label": "Shop & Service > Cosmetics Shop",
+      "is_exact": true
+    }
+  },
+  "17031": {
+    "integrated_label": "Retail > Costume Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b17",
+      "foursquare_category_label": "Shop & Service > Costume Shop",
+      "is_exact": true
+    }
+  },
+  "17032": {
+    "integrated_label": "Retail > Dance Store",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17033": {
+    "integrated_label": "Retail > Department Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f6941735",
+      "foursquare_category_label": "Shop & Service > Department Store",
+      "is_exact": true
+    }
+  },
+  "17034": {
+    "integrated_label": "Retail > Discount Store",
+    "single_match": {
+      "foursquare_category_id": "52dea92d3cf9994f4e043dbb",
+      "foursquare_category_label": "Shop & Service > Discount Store",
+      "is_exact": true
+    }
+  },
+  "17035": {
+    "integrated_label": "Retail > Drugstore",
+    "single_match": {
+      "foursquare_category_id": "5745c2e4498e11e7bccabdbd",
+      "foursquare_category_label": "Shop & Service > Drugstore",
+      "is_exact": true
+    }
+  },
+  "17036": {
+    "integrated_label": "Retail > Duty-free Store",
+    "single_match": {
+      "foursquare_category_id": "589ddde98ae3635c072819ee",
+      "foursquare_category_label": "Travel & Transport > Duty-free Shop",
+      "is_exact": true
+    }
+  },
+  "17037": {
+    "integrated_label": "Retail > Eyecare Store",
+    "single_match": {
+      "foursquare_category_id": "4d954afda243a5684865b473",
+      "foursquare_category_label": "Shop & Service > Optical Shop",
+      "is_exact": true
+    }
+  },
+  "17038": {
+    "integrated_label": "Retail > Fabric / Textiles Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b26",
+      "foursquare_category_label": "Shop & Service > Fabric Shop",
+      "is_exact": true
+    }
+  },
+  "17039": {
+    "integrated_label": "Retail > Fashion Retail",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17040": {
+    "integrated_label": "Retail > Fashion Retail > Batik Store",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734cb",
+      "foursquare_category_label": "Shop & Service > Batik Shop",
+      "is_exact": true
+    }
+  },
+  "17041": {
+    "integrated_label": "Retail > Fashion Retail > Bridal Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11a951735",
+      "foursquare_category_label": "Shop & Service > Bridal Shop",
+      "is_exact": true
+    }
+  },
+  "17042": {
+    "integrated_label": "Retail > Fashion Retail > Children's Clothing Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d105951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Kids Store",
+      "is_exact": true
+    }
+  },
+  "17043": {
+    "integrated_label": "Retail > Fashion Retail > Clothing Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d103951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store",
+      "is_exact": true
+    }
+  },
+  "17044": {
+    "integrated_label": "Retail > Fashion Retail > Fashion Accessories Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d102951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Accessories Store",
+      "is_exact": true
+    }
+  },
+  "17045": {
+    "integrated_label": "Retail > Fashion Retail > Jewelry Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d111951735",
+      "foursquare_category_label": "Shop & Service > Jewelry Store",
+      "is_exact": true
+    }
+  },
+  "17046": {
+    "integrated_label": "Retail > Fashion Retail > Lingerie Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d109951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Lingerie Store",
+      "is_exact": true
+    }
+  },
+  "17047": {
+    "integrated_label": "Retail > Fashion Retail > Men's Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d106951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Men's Store",
+      "is_exact": true
+    }
+  },
+  "17048": {
+    "integrated_label": "Retail > Fashion Retail > Shoe Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d107951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Shoe Store",
+      "is_exact": true
+    }
+  },
+  "17049": {
+    "integrated_label": "Retail > Fashion Retail > Sunglasses Store",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17050": {
+    "integrated_label": "Retail > Fashion Retail > Swimwear Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d103951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store",
+      "is_exact": false
+    }
+  },
+  "17051": {
+    "integrated_label": "Retail > Fashion Retail > Watch Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2e",
+      "foursquare_category_label": "Shop & Service > Watch Shop",
+      "is_exact": true
+    }
+  },
+  "17052": {
+    "integrated_label": "Retail > Fashion Retail > Women's Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d108951735",
+      "foursquare_category_label": "Shop & Service > Clothing Store > Women's Store",
+      "is_exact": true
+    }
+  },
+  "17053": {
+    "integrated_label": "Retail > Fireworks Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3a",
+      "foursquare_category_label": "Shop & Service > Fireworks Store",
+      "is_exact": true
+    }
+  },
+  "17054": {
+    "integrated_label": "Retail > Flea Market",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f7941735",
+      "foursquare_category_label": "Shop & Service > Flea Market",
+      "is_exact": true
+    }
+  },
+  "17055": {
+    "integrated_label": "Retail > Floating Market",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573505",
+      "foursquare_category_label": "Shop & Service > Floating Market",
+      "is_exact": true
+    }
+  },
+  "17056": {
+    "integrated_label": "Retail > Flower Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11b951735",
+      "foursquare_category_label": "Shop & Service > Flower Shop",
+      "is_exact": true
+    }
+  },
+  "17057": {
+    "integrated_label": "Retail > Food and Beverage Retail",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f9941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop",
+      "is_exact": true
+    }
+  },
+  "17058": {
+    "integrated_label": "Retail > Food and Beverage Retail > Beer Store",
+    "single_match": {
+      "foursquare_category_id": "5370f356bcbc57f1066c94c2",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Beer Store",
+      "is_exact": true
+    }
+  },
+  "17059": {
+    "integrated_label": "Retail > Food and Beverage Retail > Butcher",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11d951735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Butcher",
+      "is_exact": true
+    }
+  },
+  "17060": {
+    "integrated_label": "Retail > Food and Beverage Retail > Candy Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d117951735",
+      "foursquare_category_label": "Shop & Service > Candy Store",
+      "is_exact": true
+    }
+  },
+  "17061": {
+    "integrated_label": "Retail > Food and Beverage Retail > Cheese Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d11e951735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Cheese Shop",
+      "is_exact": true
+    }
+  },
+  "17062": {
+    "integrated_label": "Retail > Food and Beverage Retail > Chocolate Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b31",
+      "foursquare_category_label": "Shop & Service > Chocolate Shop",
+      "is_exact": true
+    }
+  },
+  "17063": {
+    "integrated_label": "Retail > Food and Beverage Retail > Coffee Roaster",
+    "single_match": {
+      "foursquare_category_id": "5e18993feee47d000759b256",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Coffee Roaster",
+      "is_exact": true
+    }
+  },
+  "17064": {
+    "integrated_label": "Retail > Food and Beverage Retail > Dairy Store",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1ca",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Dairy Store",
+      "is_exact": true
+    }
+  },
+  "17065": {
+    "integrated_label": "Retail > Food and Beverage Retail > Farmers' Market",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fa941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Farmers Market",
+      "is_exact": true
+    }
+  },
+  "17066": {
+    "integrated_label": "Retail > Food and Beverage Retail > Fish Market",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10e951735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Fish Market",
+      "is_exact": true
+    }
+  },
+  "17067": {
+    "integrated_label": "Retail > Food and Beverage Retail > Fruit and Vegetable Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b1c",
+      "foursquare_category_label": "Shop & Service > Fruit & Vegetable Store",
+      "is_exact": true
+    }
+  },
+  "17068": {
+    "integrated_label": "Retail > Food and Beverage Retail > Gourmet Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f5941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Gourmet Shop",
+      "is_exact": true
+    }
+  },
+  "17069": {
+    "integrated_label": "Retail > Food and Beverage Retail > Grocery Store / Supermarket",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d118951735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Grocery Store",
+      "is_exact": true
+    }
+  },
+  "17070": {
+    "integrated_label": "Retail > Food and Beverage Retail > Grocery Store / Supermarket > Organic Grocery",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b45",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Organic Grocery",
+      "is_exact": true
+    }
+  },
+  "17071": {
+    "integrated_label": "Retail > Food and Beverage Retail > Health Food Store",
+    "single_match": {
+      "foursquare_category_id": "50aa9e744b90af0d42d5de0e",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Health Food Store",
+      "is_exact": true
+    }
+  },
+  "17072": {
+    "integrated_label": "Retail > Food and Beverage Retail > Herbs and Spices Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2c",
+      "foursquare_category_label": "Shop & Service > Herbs & Spices Store",
+      "is_exact": true
+    }
+  },
+  "17073": {
+    "integrated_label": "Retail > Food and Beverage Retail > Imported Food Store",
+    "single_match": {
+      "foursquare_category_id": "5f2c41945b4c177b9a6dc7d6",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shops > Imported Food Shop",
+      "is_exact": true
+    }
+  },
+  "17074": {
+    "integrated_label": "Retail > Food and Beverage Retail > Kosher Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f9941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop",
+      "is_exact": false
+    }
+  },
+  "17075": {
+    "integrated_label": "Retail > Food and Beverage Retail > Kuruyemişçi Shop",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1e8",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Kuruyemişçi",
+      "is_exact": true
+    }
+  },
+  "17076": {
+    "integrated_label": "Retail > Food and Beverage Retail > Liquor Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d186941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Liquor Store",
+      "is_exact": true
+    }
+  },
+  "17077": {
+    "integrated_label": "Retail > Food and Beverage Retail > Meat and Seafood Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f9941735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop",
+      "is_exact": false
+    }
+  },
+  "17078": {
+    "integrated_label": "Retail > Food and Beverage Retail > Sausage Store",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573564",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Sausage Shop",
+      "is_exact": true
+    }
+  },
+  "17079": {
+    "integrated_label": "Retail > Food and Beverage Retail > Turşucu Shop",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1e5",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Turşucu",
+      "is_exact": true
+    }
+  },
+  "17080": {
+    "integrated_label": "Retail > Food and Beverage Retail > Wine Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d119951735",
+      "foursquare_category_label": "Shop & Service > Food & Drink Shop > Wine Shop",
+      "is_exact": true
+    }
+  },
+  "17081": {
+    "integrated_label": "Retail > Framing Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b24",
+      "foursquare_category_label": "Shop & Service > Frame Store",
+      "is_exact": true
+    }
+  },
+  "17082": {
+    "integrated_label": "Retail > Furniture and Home Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f8941735",
+      "foursquare_category_label": "Shop & Service > Furniture / Home Store",
+      "is_exact": true
+    }
+  },
+  "17083": {
+    "integrated_label": "Retail > Furniture and Home Store > Carpet Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2a",
+      "foursquare_category_label": "Shop & Service > Carpet Store",
+      "is_exact": true
+    }
+  },
+  "17084": {
+    "integrated_label": "Retail > Furniture and Home Store > Home Appliance Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f8941735",
+      "foursquare_category_label": "Shop & Service > Furniture / Home Store",
+      "is_exact": false
+    }
+  },
+  "17085": {
+    "integrated_label": "Retail > Furniture and Home Store > Housewares Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f8941735",
+      "foursquare_category_label": "Shop & Service > Furniture / Home Store",
+      "is_exact": false
+    }
+  },
+  "17086": {
+    "integrated_label": "Retail > Furniture and Home Store > Kitchen Supply Store",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1b4",
+      "foursquare_category_label": "Shop & Service > Kitchen Supply Store",
+      "is_exact": true
+    }
+  },
+  "17087": {
+    "integrated_label": "Retail > Furniture and Home Store > Lighting Store",
+    "single_match": {
+      "foursquare_category_id": "55888a5a498e782e3303b43a",
+      "foursquare_category_label": "Shop & Service > Furniture / Home Store > Lighting Store",
+      "is_exact": true
+    }
+  },
+  "17088": {
+    "integrated_label": "Retail > Furniture and Home Store > Mattress Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b27",
+      "foursquare_category_label": "Shop & Service > Mattress Store",
+      "is_exact": true
+    }
+  },
+  "17089": {
+    "integrated_label": "Retail > Gift Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d128951735",
+      "foursquare_category_label": "Shop & Service > Gift Shop",
+      "is_exact": true
+    }
+  },
+  "17090": {
+    "integrated_label": "Retail > Hardware Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d112951735",
+      "foursquare_category_label": "Shop & Service > Hardware Store",
+      "is_exact": true
+    }
+  },
+  "17091": {
+    "integrated_label": "Retail > Hobby Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fb941735",
+      "foursquare_category_label": "Shop & Service > Hobby Shop",
+      "is_exact": true
+    }
+  },
+  "17092": {
+    "integrated_label": "Retail > Knitting Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b25",
+      "foursquare_category_label": "Shop & Service > Knitting Store",
+      "is_exact": true
+    }
+  },
+  "17093": {
+    "integrated_label": "Retail > Leather Goods Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b2b",
+      "foursquare_category_label": "Shop & Service > Leather Goods Store",
+      "is_exact": true
+    }
+  },
+  "17094": {
+    "integrated_label": "Retail > Luggage Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b29",
+      "foursquare_category_label": "Shop & Service > Luggage Store",
+      "is_exact": true
+    }
+  },
+  "17095": {
+    "integrated_label": "Retail > Medical Supply Store",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec206",
+      "foursquare_category_label": "Shop & Service > Medical Supply Store",
+      "is_exact": true
+    }
+  },
+  "17096": {
+    "integrated_label": "Retail > Miscellaneous Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ff941735",
+      "foursquare_category_label": "Shop & Service > Miscellaneous Shop",
+      "is_exact": true
+    }
+  },
+  "17097": {
+    "integrated_label": "Retail > Mobility Store",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57354a",
+      "foursquare_category_label": "Shop & Service > Mobility Store",
+      "is_exact": true
+    }
+  },
+  "17098": {
+    "integrated_label": "Retail > Music Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fe941735",
+      "foursquare_category_label": "Shop & Service > Music Store",
+      "is_exact": true
+    }
+  },
+  "17099": {
+    "integrated_label": "Retail > Newsagent",
+    "single_match": {
+      "foursquare_category_id": "5f2c5a295b4c177b9a6ddd0e",
+      "foursquare_category_label": "Shop & Service > Newsagents",
+      "is_exact": true
+    }
+  },
+  "17100": {
+    "integrated_label": "Retail > Newsstand",
+    "single_match": {
+      "foursquare_category_id": "4f04ad622fb6e1c99f3db0b9",
+      "foursquare_category_label": "Shop & Service > Newsstand",
+      "is_exact": true
+    }
+  },
+  "17101": {
+    "integrated_label": "Retail > Garden Center",
+    "single_match": {
+      "foursquare_category_id": "4eb1c0253b7b52c0e1adc2e9",
+      "foursquare_category_label": "Shop & Service > Garden Center",
+      "is_exact": true
+    }
+  },
+  "17102": {
+    "integrated_label": "Retail > Office Supply Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d121951735",
+      "foursquare_category_label": "Shop & Service > Paper / Office Supplies Store",
+      "is_exact": true
+    }
+  },
+  "17103": {
+    "integrated_label": "Retail > Outdoor Supply Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b22",
+      "foursquare_category_label": "Shop & Service > Outdoor Supply Store",
+      "is_exact": true
+    }
+  },
+  "17104": {
+    "integrated_label": "Retail > Outlet Mall",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4df",
+      "foursquare_category_label": "Shop & Service > Outlet Mall",
+      "is_exact": true
+    }
+  },
+  "17105": {
+    "integrated_label": "Retail > Outlet Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b35",
+      "foursquare_category_label": "Shop & Service > Outlet Store",
+      "is_exact": true
+    }
+  },
+  "17106": {
+    "integrated_label": "Retail > Packaging Supply Store",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17107": {
+    "integrated_label": "Retail > Party Supply Store",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17108": {
+    "integrated_label": "Retail > Pawn Shop",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b34",
+      "foursquare_category_label": "Shop & Service > Pawn Shop",
+      "is_exact": true
+    }
+  },
+  "17109": {
+    "integrated_label": "Retail > Perfume Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b23",
+      "foursquare_category_label": "Shop & Service > Perfume Shop",
+      "is_exact": true
+    }
+  },
+  "17110": {
+    "integrated_label": "Retail > Pet Supplies Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d100951735",
+      "foursquare_category_label": "Shop & Service > Pet Store",
+      "is_exact": false
+    }
+  },
+  "17111": {
+    "integrated_label": "Retail > Pop-Up Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b3d",
+      "foursquare_category_label": "Shop & Service > Pop-Up Shop",
+      "is_exact": true
+    }
+  },
+  "17112": {
+    "integrated_label": "Retail > Print Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b28",
+      "foursquare_category_label": "Shop & Service > Print Shop",
+      "is_exact": true
+    }
+  },
+  "17113": {
+    "integrated_label": "Retail > Record Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d10d951735",
+      "foursquare_category_label": "Shop & Service > Record Shop",
+      "is_exact": true
+    }
+  },
+  "17114": {
+    "integrated_label": "Retail > Shopping Mall",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fd941735",
+      "foursquare_category_label": "Shop & Service > Shopping Mall",
+      "is_exact": true
+    }
+  },
+  "17115": {
+    "integrated_label": "Retail > Shopping Plaza",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4dc",
+      "foursquare_category_label": "Shop & Service > Shopping Plaza",
+      "is_exact": true
+    }
+  },
+  "17116": {
+    "integrated_label": "Retail > Souvenir Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b1b",
+      "foursquare_category_label": "Shop & Service > Souvenir Shop",
+      "is_exact": true
+    }
+  },
+  "17117": {
+    "integrated_label": "Retail > Sporting Goods Retail",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": true
+    }
+  },
+  "17118": {
+    "integrated_label": "Retail > Sporting Goods Retail > Baseball Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17119": {
+    "integrated_label": "Retail > Sporting Goods Retail > Bicycle Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d115951735",
+      "foursquare_category_label": "Shop & Service > Bike Shop",
+      "is_exact": true
+    }
+  },
+  "17120": {
+    "integrated_label": "Retail > Sporting Goods Retail > Dive Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b1a",
+      "foursquare_category_label": "Shop & Service > Dive Shop",
+      "is_exact": true
+    }
+  },
+  "17121": {
+    "integrated_label": "Retail > Sporting Goods Retail > Fishing Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b16",
+      "foursquare_category_label": "Shop & Service > Fishing Store",
+      "is_exact": true
+    }
+  },
+  "17122": {
+    "integrated_label": "Retail > Sporting Goods Retail > Golf Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17123": {
+    "integrated_label": "Retail > Sporting Goods Retail > Gun Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b19",
+      "foursquare_category_label": "Shop & Service > Gun Shop",
+      "is_exact": true
+    }
+  },
+  "17124": {
+    "integrated_label": "Retail > Sporting Goods Retail > Hunting Supply Store",
+    "single_match": {
+      "foursquare_category_id": "50aaa5234b90af0d42d5de12",
+      "foursquare_category_label": "Shop & Service > Hunting Supply",
+      "is_exact": true
+    }
+  },
+  "17125": {
+    "integrated_label": "Retail > Sporting Goods Retail > Running Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17126": {
+    "integrated_label": "Retail > Sporting Goods Retail > Skate Store",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89d2",
+      "foursquare_category_label": "Shop & Service > Skate Shop",
+      "is_exact": true
+    }
+  },
+  "17127": {
+    "integrated_label": "Retail > Sporting Goods Retail > Ski Store",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573566",
+      "foursquare_category_label": "Shop & Service > Ski Shop",
+      "is_exact": true
+    }
+  },
+  "17128": {
+    "integrated_label": "Retail > Sporting Goods Retail > Soccer Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17129": {
+    "integrated_label": "Retail > Sporting Goods Retail > Surf Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17130": {
+    "integrated_label": "Retail > Sporting Goods Retail > Tennis Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f2941735",
+      "foursquare_category_label": "Shop & Service > Sporting Goods Shop",
+      "is_exact": false
+    }
+  },
+  "17131": {
+    "integrated_label": "Retail > Stationery Store",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b21",
+      "foursquare_category_label": "Shop & Service > Stationery Store",
+      "is_exact": true
+    }
+  },
+  "17132": {
+    "integrated_label": "Retail > Supplement Store",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4cd",
+      "foursquare_category_label": "Shop & Service > Supplement Shop",
+      "is_exact": true
+    }
+  },
+  "17133": {
+    "integrated_label": "Retail > Swimming Pool Supply Store",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06378d81259",
+      "foursquare_category_label": "Shop & Service",
+      "is_exact": false
+    }
+  },
+  "17134": {
+    "integrated_label": "Retail > Tobacco Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d123951735",
+      "foursquare_category_label": "Shop & Service > Smoke Shop",
+      "is_exact": true
+    }
+  },
+  "17135": {
+    "integrated_label": "Retail > Toy / Game Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f3941735",
+      "foursquare_category_label": "Shop & Service > Toy / Game Store",
+      "is_exact": true
+    }
+  },
+  "17136": {
+    "integrated_label": "Retail > Vaporizer Store",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57355c",
+      "foursquare_category_label": "Shop & Service > Vape Store",
+      "is_exact": true
+    }
+  },
+  "17137": {
+    "integrated_label": "Retail > Video Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d126951735",
+      "foursquare_category_label": "Shop & Service > Video Store",
+      "is_exact": true
+    }
+  },
+  "17138": {
+    "integrated_label": "Retail > Vintage and Thrift Store",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d101951735",
+      "foursquare_category_label": "Shop & Service > Thrift / Vintage Store",
+      "is_exact": true
+    }
+  },
+  "17139": {
+    "integrated_label": "Retail > Warehouse / Wholesale Store",
+    "single_match": {
+      "foursquare_category_id": "52e816a6bcbc57f1066b7a54",
+      "foursquare_category_label": "Shop & Service > Warehouse Store",
+      "is_exact": true
+    }
+  },
+  "18000": {
+    "integrated_label": "Sports and Recreation",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": true
+    }
+  },
+  "18001": {
+    "integrated_label": "Sports and Recreation > Athletic Field",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18002": {
+    "integrated_label": "Sports and Recreation > Baseball",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18003": {
+    "integrated_label": "Sports and Recreation > Baseball > Baseball Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18004": {
+    "integrated_label": "Sports and Recreation > Baseball > Baseball Field",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e8941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Baseball Field",
+      "is_exact": true
+    }
+  },
+  "18005": {
+    "integrated_label": "Sports and Recreation > Baseball > Batting Range",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18006": {
+    "integrated_label": "Sports and Recreation > Basketball",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18007": {
+    "integrated_label": "Sports and Recreation > Basketball > Basketball Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18008": {
+    "integrated_label": "Sports and Recreation > Basketball > Basketball Court",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e1941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Basketball Court",
+      "is_exact": true
+    }
+  },
+  "18009": {
+    "integrated_label": "Sports and Recreation > Bowling Green",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2f",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Bowling Green",
+      "is_exact": true
+    }
+  },
+  "18010": {
+    "integrated_label": "Sports and Recreation > Cricket Ground",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d18a941735",
+      "foursquare_category_label": "Arts & Entertainment > Stadium > Cricket Ground",
+      "is_exact": true
+    }
+  },
+  "18011": {
+    "integrated_label": "Sports and Recreation > Curling Ice",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57351a",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Curling Ice",
+      "is_exact": true
+    }
+  },
+  "18012": {
+    "integrated_label": "Sports and Recreation > Equestrian Facility",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18013": {
+    "integrated_label": "Sports and Recreation > Football",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18014": {
+    "integrated_label": "Sports and Recreation > Football > Football Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18015": {
+    "integrated_label": "Sports and Recreation > Football > Football Field",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18016": {
+    "integrated_label": "Sports and Recreation > Golf",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18017": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18018": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Course",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e6941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Golf Course",
+      "is_exact": true
+    }
+  },
+  "18019": {
+    "integrated_label": "Sports and Recreation > Golf > Golf Driving Range",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1b0",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Golf Driving Range",
+      "is_exact": true
+    }
+  },
+  "18020": {
+    "integrated_label": "Sports and Recreation > Gun Range",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a11",
+      "foursquare_category_label": "Outdoors & Recreation > Gun Range",
+      "is_exact": true
+    }
+  },
+  "18021": {
+    "integrated_label": "Sports and Recreation > Gym and Studio",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d175941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center",
+      "is_exact": true
+    }
+  },
+  "18022": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Boxing Gym",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b47",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Boxing Gym",
+      "is_exact": true
+    }
+  },
+  "18023": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Climbing Gym",
+    "single_match": {
+      "foursquare_category_id": "503289d391d4c4b30a586d6a",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Climbing Gym",
+      "is_exact": true
+    }
+  },
+  "18024": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Cycle Studio",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b49",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Cycle Studio",
+      "is_exact": true
+    }
+  },
+  "18025": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Dance Studio",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d134941735",
+      "foursquare_category_label": "Arts & Entertainment > Performing Arts Venue > Dance Studio",
+      "is_exact": true
+    }
+  },
+  "18026": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Outdoor Gym",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec203",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Outdoor Gym",
+      "is_exact": true
+    }
+  },
+  "18027": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Pilates Studio",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4b2",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Pilates Studio",
+      "is_exact": true
+    }
+  },
+  "18028": {
+    "integrated_label": "Sports and Recreation > Gym and Studio > Yoga Studio",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d102941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Yoga Studio",
+      "is_exact": true
+    }
+  },
+  "18029": {
+    "integrated_label": "Sports and Recreation > Gymnastics",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18030": {
+    "integrated_label": "Sports and Recreation > Gymnastics > Gymnastics Center",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b48",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Gymnastics Gym",
+      "is_exact": true
+    }
+  },
+  "18031": {
+    "integrated_label": "Sports and Recreation > Hockey",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18032": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18033": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Field",
+    "single_match": {
+      "foursquare_category_id": "4f452cd44b9081a197eba860",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Hockey Field",
+      "is_exact": true
+    }
+  },
+  "18034": {
+    "integrated_label": "Sports and Recreation > Hockey > Hockey Rink",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57352c",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Hockey Rink",
+      "is_exact": true
+    }
+  },
+  "18035": {
+    "integrated_label": "Sports and Recreation > Indoor Play Area",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4b5",
+      "foursquare_category_label": "Outdoors & Recreation > Indoor Play Area",
+      "is_exact": true
+    }
+  },
+  "18036": {
+    "integrated_label": "Sports and Recreation > Martial Arts Dojo",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d101941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Martial Arts Dojo",
+      "is_exact": true
+    }
+  },
+  "18037": {
+    "integrated_label": "Sports and Recreation > Paintball Field",
+    "single_match": {
+      "foursquare_category_id": "5032829591d4c4b30a586d5e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Paintball Field",
+      "is_exact": true
+    }
+  },
+  "18038": {
+    "integrated_label": "Sports and Recreation > Personal Trainer",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18039": {
+    "integrated_label": "Sports and Recreation > Race Track",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f4931735",
+      "foursquare_category_label": "Arts & Entertainment > Racetrack",
+      "is_exact": true
+    }
+  },
+  "18040": {
+    "integrated_label": "Sports and Recreation > Racquet Sports",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18041": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Badminton Court",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2b",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Badminton Court",
+      "is_exact": true
+    }
+  },
+  "18042": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Racquet Sport Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18043": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Racquetball Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18044": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Squash Court",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2d",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Squash Court",
+      "is_exact": true
+    }
+  },
+  "18045": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18046": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis > Tennis Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18047": {
+    "integrated_label": "Sports and Recreation > Racquet Sports > Tennis > Tennis Court",
+    "single_match": {
+      "foursquare_category_id": "4e39a956bd410d7aed40cbc3",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Tennis Court",
+      "is_exact": true
+    }
+  },
+  "18048": {
+    "integrated_label": "Sports and Recreation > Recreation Center",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a26",
+      "foursquare_category_label": "Outdoors & Recreation > Recreation Center",
+      "is_exact": true
+    }
+  },
+  "18049": {
+    "integrated_label": "Sports and Recreation > Rugby",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18050": {
+    "integrated_label": "Sports and Recreation > Rugby > Rugby Pitch",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2c",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Rugby Pitch",
+      "is_exact": true
+    }
+  },
+  "18051": {
+    "integrated_label": "Sports and Recreation > Running and Track",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18052": {
+    "integrated_label": "Sports and Recreation > Running and Track > Running Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18053": {
+    "integrated_label": "Sports and Recreation > Running and Track > Track",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d106941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Gym / Fitness Center > Track",
+      "is_exact": true
+    }
+  },
+  "18054": {
+    "integrated_label": "Sports and Recreation > Skating",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18055": {
+    "integrated_label": "Sports and Recreation > Skating > Skate Park",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d167941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Skate Park",
+      "is_exact": true
+    }
+  },
+  "18056": {
+    "integrated_label": "Sports and Recreation > Skating > Skating Rink",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d168941735",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Skating Rink",
+      "is_exact": true
+    }
+  },
+  "18057": {
+    "integrated_label": "Sports and Recreation > Skydiving Center",
+    "single_match": {
+      "foursquare_category_id": "58daa1558bbb0b01f18ec1b9",
+      "foursquare_category_label": "Outdoors & Recreation > Skydiving Drop Zone",
+      "is_exact": true
+    }
+  },
+  "18058": {
+    "integrated_label": "Sports and Recreation > Snow Sports",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18059": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Chalet",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ec941735",
+      "foursquare_category_label": "Outdoors & Recreation > Ski Area > Ski Chalet",
+      "is_exact": true
+    }
+  },
+  "18060": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Lodge",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1eb941735",
+      "foursquare_category_label": "Outdoors & Recreation > Ski Area > Ski Lodge",
+      "is_exact": true
+    }
+  },
+  "18061": {
+    "integrated_label": "Sports and Recreation > Snow Sports > Ski Resorts and Areas",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1e9941735",
+      "foursquare_category_label": "Outdoors & Recreation > Ski Area",
+      "is_exact": true
+    }
+  },
+  "18062": {
+    "integrated_label": "Sports and Recreation > Soccer",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18063": {
+    "integrated_label": "Sports and Recreation > Soccer > Soccer Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18064": {
+    "integrated_label": "Sports and Recreation > Soccer > Soccer Field",
+    "single_match": {
+      "foursquare_category_id": "4cce455aebf7b749d5e191f5",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Soccer Field",
+      "is_exact": true
+    }
+  },
+  "18065": {
+    "integrated_label": "Sports and Recreation > Sports Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": true
+    }
+  },
+  "18066": {
+    "integrated_label": "Sports and Recreation > Volleyball Court",
+    "single_match": {
+      "foursquare_category_id": "4eb1bf013b7b6f98df247e07",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Volleyball Court",
+      "is_exact": true
+    }
+  },
+  "18067": {
+    "integrated_label": "Sports and Recreation > Water Sports",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18068": {
+    "integrated_label": "Sports and Recreation > Water Sports > Canoe and Kayak Rental",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4c1",
+      "foursquare_category_label": "Travel & Transport > Boat Rental",
+      "is_exact": false
+    }
+  },
+  "18069": {
+    "integrated_label": "Sports and Recreation > Water Sports > Rafting Outfitter",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a29",
+      "foursquare_category_label": "Outdoors & Recreation > Rafting",
+      "is_exact": true
+    }
+  },
+  "18070": {
+    "integrated_label": "Sports and Recreation > Water Sports > Sailing Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18071": {
+    "integrated_label": "Sports and Recreation > Water Sports > Scuba Diving Instructor",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18072": {
+    "integrated_label": "Sports and Recreation > Water Sports > Surfing",
+    "single_match": {
+      "foursquare_category_id": "4f4528bc4b90abdf24c9de85",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports",
+      "is_exact": false
+    }
+  },
+  "18073": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18074": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swimming Club",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a2e",
+      "foursquare_category_label": "Outdoors & Recreation > Athletics & Sports > Sports Club",
+      "is_exact": false
+    }
+  },
+  "18075": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swimming Pool",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d15e941735",
+      "foursquare_category_label": "Outdoors & Recreation > Pool",
+      "is_exact": true
+    }
+  },
+  "18076": {
+    "integrated_label": "Sports and Recreation > Water Sports > Swimming > Swim School",
+    "single_match": {
+      "foursquare_category_id": "52e81612bcbc57f1066b7a44",
+      "foursquare_category_label": "Professional & Other Places > School > Swim School",
+      "is_exact": true
+    }
+  },
+  "19000": {
+    "integrated_label": "Travel and Transportation",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06379d81259",
+      "foursquare_category_label": "Travel & Transport",
+      "is_exact": true
+    }
+  },
+  "19001": {
+    "integrated_label": "Travel and Transportation > Baggage Locker",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4e8",
+      "foursquare_category_label": "Travel & Transport > Baggage Locker",
+      "is_exact": true
+    }
+  },
+  "19002": {
+    "integrated_label": "Travel and Transportation > Bike Rental",
+    "single_match": {
+      "foursquare_category_id": "4e4c9077bd41f78e849722f9",
+      "foursquare_category_label": "Travel & Transport > Bike Rental / Bike Share",
+      "is_exact": true
+    }
+  },
+  "19003": {
+    "integrated_label": "Travel and Transportation > Boat Rental",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4c1",
+      "foursquare_category_label": "Travel & Transport > Boat Rental",
+      "is_exact": true
+    }
+  },
+  "19004": {
+    "integrated_label": "Travel and Transportation > Border Crossing",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b4b",
+      "foursquare_category_label": "Travel & Transport > Border Crossing",
+      "is_exact": true
+    }
+  },
+  "19005": {
+    "integrated_label": "Travel and Transportation > Cruise",
+    "single_match": {
+      "foursquare_category_id": "55077a22498e5e9248869ba2",
+      "foursquare_category_label": "Travel & Transport > Cruise Ship",
+      "is_exact": true
+    }
+  },
+  "19006": {
+    "integrated_label": "Travel and Transportation > Electric Vehicle Charging Station",
+    "single_match": {
+      "foursquare_category_id": "5032872391d4c4b30a586d64",
+      "foursquare_category_label": "Shop & Service > EV Charging Station",
+      "is_exact": true
+    }
+  },
+  "19007": {
+    "integrated_label": "Travel and Transportation > Fuel Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d113951735",
+      "foursquare_category_label": "Shop & Service > Gas Station",
+      "is_exact": true
+    }
+  },
+  "19008": {
+    "integrated_label": "Travel and Transportation > Hot Air Balloon Tour Agency",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573520",
+      "foursquare_category_label": "Arts & Entertainment > Tour Provider",
+      "is_exact": false
+    }
+  },
+  "19009": {
+    "integrated_label": "Travel and Transportation > Lodging",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06379d81259",
+      "foursquare_category_label": "Travel & Transport",
+      "is_exact": false
+    }
+  },
+  "19010": {
+    "integrated_label": "Travel and Transportation > Lodging > Bed and Breakfast",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f8931735",
+      "foursquare_category_label": "Travel & Transport > Hotel > Bed & Breakfast",
+      "is_exact": true
+    }
+  },
+  "19011": {
+    "integrated_label": "Travel and Transportation > Lodging > Boarding House",
+    "single_match": {
+      "foursquare_category_id": "4f4530a74b9074f6e4fb0100",
+      "foursquare_category_label": "Travel & Transport > Hotel > Boarding House",
+      "is_exact": true
+    }
+  },
+  "19012": {
+    "integrated_label": "Travel and Transportation > Lodging > Cottage / Cabin",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06379d81259",
+      "foursquare_category_label": "Travel & Transport",
+      "is_exact": false
+    }
+  },
+  "19013": {
+    "integrated_label": "Travel and Transportation > Lodging > Hostel",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ee931735",
+      "foursquare_category_label": "Travel & Transport > Hotel > Hostel",
+      "is_exact": true
+    }
+  },
+  "19014": {
+    "integrated_label": "Travel and Transportation > Lodging > Hotel",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fa931735",
+      "foursquare_category_label": "Travel & Transport > Hotel",
+      "is_exact": true
+    }
+  },
+  "19015": {
+    "integrated_label": "Travel and Transportation > Lodging > Inn",
+    "single_match": {
+      "foursquare_category_id": "5bae9231bedf3950379f89cb",
+      "foursquare_category_label": "Travel & Transport > Hotel > Inn",
+      "is_exact": true
+    }
+  },
+  "19016": {
+    "integrated_label": "Travel and Transportation > Lodging > Lodge",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06379d81259",
+      "foursquare_category_label": "Travel & Transport",
+      "is_exact": false
+    }
+  },
+  "19017": {
+    "integrated_label": "Travel and Transportation > Lodging > Motel",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fb931735",
+      "foursquare_category_label": "Travel & Transport > Hotel > Motel",
+      "is_exact": true
+    }
+  },
+  "19018": {
+    "integrated_label": "Travel and Transportation > Lodging > Resort",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d12f951735",
+      "foursquare_category_label": "Travel & Transport > Hotel > Resort",
+      "is_exact": true
+    }
+  },
+  "19019": {
+    "integrated_label": "Travel and Transportation > Lodging > Vacation Rental",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d5734e1",
+      "foursquare_category_label": "Travel & Transport > Hotel > Vacation Rental",
+      "is_exact": true
+    }
+  },
+  "19020": {
+    "integrated_label": "Travel and Transportation > Parking",
+    "single_match": {
+      "foursquare_category_id": "4c38df4de52ce0d596b336e1",
+      "foursquare_category_label": "Professional & Other Places > Parking",
+      "is_exact": true
+    }
+  },
+  "19021": {
+    "integrated_label": "Travel and Transportation > Pier",
+    "single_match": {
+      "foursquare_category_id": "4e74f6cabd41c4836eac4c31",
+      "foursquare_category_label": "Travel & Transport > Pier",
+      "is_exact": true
+    }
+  },
+  "19022": {
+    "integrated_label": "Travel and Transportation > Platform",
+    "single_match": {
+      "foursquare_category_id": "4f4531504b9074f6e4fb0102",
+      "foursquare_category_label": "Travel & Transport > Train Station > Platform",
+      "is_exact": true
+    }
+  },
+  "19023": {
+    "integrated_label": "Travel and Transportation > Port",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57353e",
+      "foursquare_category_label": "Travel & Transport > Port",
+      "is_exact": true
+    }
+  },
+  "19024": {
+    "integrated_label": "Travel and Transportation > Rest Area",
+    "single_match": {
+      "foursquare_category_id": "4d954b16a243a5684b65b473",
+      "foursquare_category_label": "Travel & Transport > Rest Area",
+      "is_exact": true
+    }
+  },
+  "19025": {
+    "integrated_label": "Travel and Transportation > RV Park",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b53",
+      "foursquare_category_label": "Travel & Transport > RV Park",
+      "is_exact": true
+    }
+  },
+  "19026": {
+    "integrated_label": "Travel and Transportation > Toll Booth",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b4d",
+      "foursquare_category_label": "Travel & Transport > Toll Booth",
+      "is_exact": true
+    }
+  },
+  "19027": {
+    "integrated_label": "Travel and Transportation > Toll Plaza",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b4e",
+      "foursquare_category_label": "Travel & Transport > Toll Plaza",
+      "is_exact": true
+    }
+  },
+  "19028": {
+    "integrated_label": "Travel and Transportation > Tourist Information and Service",
+    "single_match": {
+      "foursquare_category_id": "4f4530164b9074f6e4fb00ff",
+      "foursquare_category_label": "Travel & Transport > Tourist Information Center",
+      "is_exact": true
+    }
+  },
+  "19029": {
+    "integrated_label": "Travel and Transportation > Tourist Information and Service > Tour Provider",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d573520",
+      "foursquare_category_label": "Arts & Entertainment > Tour Provider",
+      "is_exact": true
+    }
+  },
+  "19030": {
+    "integrated_label": "Travel and Transportation > Transport Hub",
+    "single_match": {
+      "foursquare_category_id": "4d4b7105d754a06379d81259",
+      "foursquare_category_label": "Travel & Transport",
+      "is_exact": false
+    }
+  },
+  "19031": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ed931735",
+      "foursquare_category_label": "Travel & Transport > Airport",
+      "is_exact": true
+    }
+  },
+  "19032": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airfield",
+    "single_match": {
+      "foursquare_category_id": "5f2c42335b4c177b9a6dc927",
+      "foursquare_category_label": "Travel & Transport > Airport > Airfield",
+      "is_exact": true
+    }
+  },
+  "19033": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Food Court",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ef931735",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Food Court",
+      "is_exact": true
+    }
+  },
+  "19034": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Gate",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1f0931735",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Gate",
+      "is_exact": true
+    }
+  },
+  "19035": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Lounge",
+    "single_match": {
+      "foursquare_category_id": "4eb1bc533b7b2c5b1d4306cb",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Lounge",
+      "is_exact": true
+    }
+  },
+  "19036": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Service",
+    "single_match": {
+      "foursquare_category_id": "56aa371be4b08b9a8d57352f",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Service",
+      "is_exact": true
+    }
+  },
+  "19037": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Terminal",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1eb931735",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Terminal",
+      "is_exact": true
+    }
+  },
+  "19038": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Airport Tram Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ec931735",
+      "foursquare_category_label": "Travel & Transport > Airport > Airport Tram",
+      "is_exact": true
+    }
+  },
+  "19039": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Baggage Claim",
+    "single_match": {
+      "foursquare_category_id": "5744ccdfe4b0c0459246b4e5",
+      "foursquare_category_label": "Travel & Transport > Airport > Baggage Claim",
+      "is_exact": true
+    }
+  },
+  "19040": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > International Airport",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ed931735",
+      "foursquare_category_label": "Travel & Transport > Airport",
+      "is_exact": false
+    }
+  },
+  "19041": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Airport > Private Airport",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ed931735",
+      "foursquare_category_label": "Travel & Transport > Airport",
+      "is_exact": false
+    }
+  },
+  "19042": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Bus Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fe931735",
+      "foursquare_category_label": "Travel & Transport > Bus Station",
+      "is_exact": true
+    }
+  },
+  "19043": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Bus Stop",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b4f",
+      "foursquare_category_label": "Travel & Transport > Bus Stop",
+      "is_exact": true
+    }
+  },
+  "19044": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Heliport",
+    "single_match": {
+      "foursquare_category_id": "56aa371ce4b08b9a8d57356e",
+      "foursquare_category_label": "Travel & Transport > Heliport",
+      "is_exact": true
+    }
+  },
+  "19045": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Marine Terminal",
+    "single_match": {
+      "foursquare_category_id": "5f2c1af1b6d05514c704319d",
+      "foursquare_category_label": "Travel & Transport > Marine Terminal",
+      "is_exact": true
+    }
+  },
+  "19046": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Metro Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1fd931735",
+      "foursquare_category_label": "Travel & Transport > Metro Station",
+      "is_exact": true
+    }
+  },
+  "19047": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Rail Station",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d129951735",
+      "foursquare_category_label": "Travel & Transport > Train Station",
+      "is_exact": true
+    }
+  },
+  "19048": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Rental Car Location",
+    "single_match": {
+      "foursquare_category_id": "4bf58dd8d48988d1ef941735",
+      "foursquare_category_label": "Travel & Transport > Rental Car Location",
+      "is_exact": true
+    }
+  },
+  "19049": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Taxi Stand",
+    "single_match": {
+      "foursquare_category_id": "53fca564498e1a175f32528b",
+      "foursquare_category_label": "Travel & Transport > Taxi Stand",
+      "is_exact": true
+    }
+  },
+  "19050": {
+    "integrated_label": "Travel and Transportation > Transport Hub > Tram Station",
+    "single_match": {
+      "foursquare_category_id": "52f2ab2ebcbc57f1066b8b51",
+      "foursquare_category_label": "Travel & Transport > Train Station > Tram Station",
+      "is_exact": true
+    }
+  },
+  "19051": {
+    "integrated_label": "Travel and Transportation > Transportation Service",
+    "single_match": {
+      "foursquare_category_id": "54541b70498ea6ccd0204bff",
+      "foursquare_category_label": "Travel & Transport > Transportation Service",
+      "is_exact": true
+    }
+  },
+  "19052": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Charter Bus",
+    "single_match": {
+      "foursquare_category_id": "54541b70498ea6ccd0204bff",
+      "foursquare_category_label": "Travel & Transport > Transportation Service",
+      "is_exact": false
+    }
+  },
+  "19053": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Limo / Chauffeur",
+    "single_match": {
+      "foursquare_category_id": "54541b70498ea6ccd0204bff",
+      "foursquare_category_label": "Travel & Transport > Transportation Service",
+      "is_exact": false
+    }
+  },
+  "19054": {
+    "integrated_label": "Travel and Transportation > Transportation Service > Public Transportation",
+    "single_match": {
+      "foursquare_category_id": "54541b70498ea6ccd0204bff",
+      "foursquare_category_label": "Travel & Transport > Transportation Service",
+      "is_exact": false
+    }
+  },
+  "19055": {
+    "integrated_label": "Travel and Transportation > Travel Agency",
+    "single_match": {
+      "foursquare_category_id": "4f04b08c2fb6e1c99f3db0bd",
+      "foursquare_category_label": "Shop & Service > Travel Agency",
+      "is_exact": true
+    }
+  },
+  "19056": {
+    "integrated_label": "Travel and Transportation > Travel Lounge",
+    "single_match": {
+      "foursquare_category_id": "4f04b25d2fb6e1c99f3db0c0",
+      "foursquare_category_label": "Travel & Transport > Travel Lounge",
+      "is_exact": true
+    }
+  }
+}


### PR DESCRIPTION
This PR mainly adds 2 files that are mappings of:
- fsq -> legacy Factual
- fsq -> legacy Foursquare (venues)


There are also some other changes in this PR; 
- there were some missing Venues categories in the  legacy Foursquare (venues) -> fsq mapping (Dam, Picnic Area, Picnic Shelter, Architecture Firm, Boat Launch, University).
- fsq taxonomy updates (some dining and drinking categories moved under parent Restaurant)


These mapping files will be used in the published categories scala lib: https://github.com/Factual/places-categories/pull/67